### PR TITLE
Simply add a new Deep Blue theme

### DIFF
--- a/packages/altair-app/src/app/services/theme/defaults/deep_blue.ts
+++ b/packages/altair-app/src/app/services/theme/defaults/deep_blue.ts
@@ -1,0 +1,30 @@
+import { ICustomTheme, createTheme } from '../theme';
+
+const theme: ICustomTheme = {
+  colors: {
+    bg: '#030320',
+    offBg: '#08082b',
+    font: '#f2f1e8',
+    offFont: '#f2f1e8',
+    border: '#40414d',
+    offBorder: '#383942',
+    headerBg: '#08082b',
+  },
+  editor: {
+    colors: {
+      comment: '#626a73',
+      string: '#f2f1e8',
+      number: '#ffd674',
+      variable: '#e34545',
+      attribute: '#a8e197',
+      keyword: '#e34545',
+      atom: '#ff8bcb',
+      property: '#69a9e3',
+      punctuation: '#535374',
+      cursor: '#e34545',
+      definition: '#e34545',
+    }
+  }
+};
+
+export default theme;

--- a/packages/altair-app/src/app/services/theme/index.ts
+++ b/packages/altair-app/src/app/services/theme/index.ts
@@ -1,8 +1,10 @@
 import lightTheme from './defaults/light';
 import darkTheme from './defaults/dark';
 import draculaTheme from './defaults/dracula';
+import deepblueTheme from './defaults/deep_blue';
 
 export * from './theme';
 export const light = lightTheme;
 export const dark = darkTheme;
 export const dracula = draculaTheme;
+export const sven = deepblueTheme;

--- a/packages/altair-app/src/app/services/theme/theme-registry.service.ts
+++ b/packages/altair-app/src/app/services/theme/theme-registry.service.ts
@@ -3,6 +3,7 @@ import { ITheme, ICustomTheme, mergeThemes } from './theme';
 import light from './defaults/light';
 import dark from './defaults/dark';
 import dracula from './defaults/dracula';
+import deep_blue from './defaults/deep_blue';
 
 @Injectable({
   providedIn: 'root'
@@ -19,6 +20,7 @@ export class ThemeRegistryService {
     this.registry.set('light', light);
     this.registry.set('dark', dark);
     this.registry.set('dracula', dracula);
+    this.registry.set('deep_blue', deep_blue);
   }
 
   getTheme(name: string) {


### PR DESCRIPTION
<img width="1730" alt="Screenshot 2021-04-16 at 09 49 04" src="https://user-images.githubusercontent.com/36718299/114993755-1d495800-9e6a-11eb-94d4-b8f45617e011.png">

- Non of the existing themes are really that dark. I figured I would add
  one which is darker and has a bit more flair. Takes some inspiration
from Abyss

### Fixes #
Nothing fixed here as it is an enhancement

### Checks

- [x] Ran `yarn test-build`
- [x] Updated relevant documentations

### Changes proposed in this pull request:
- Add a new theme option called `deep_blue`
- Accessible through Settings > Theme > deep_blue
