### PR TITLE
add variable checker to full url checker

### DIFF
--- a/packages/altair-app/src/app/modules/altair/utils/index.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/utils/index.spec.ts
@@ -50,18 +50,18 @@ describe('utils', () => {
     });
 
     describe('.getFullUrl', () => {
-        it('should not change the value', () => {
+        it('should not change the value when including env variable', () => {
             const envVariable = '{{endpointUrl}}';
             const result = getFullUrl(envVariable);
             expect(result).toBe(envVariable);
         });
-        it('should not change the value', () => {
-            const url = 'https://test.com/grapqhl';
+        it('should not change the value for a valid absolute url', () => {
+            const url = 'https://test.com/graphql';
             const result = getFullUrl(url);
             expect(result).toBe(url);
         });
         it('should prepend text with origin location', () => {
-            const endpoint = 'grapqhl';
+            const endpoint = 'graphql';
             const result = getFullUrl(endpoint);
             expect(result).toBe(location.origin + "/" + endpoint);
         });

--- a/packages/altair-app/src/app/modules/altair/utils/index.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/utils/index.spec.ts
@@ -1,4 +1,4 @@
-import { setByDotNotation, truncateText } from '.';
+import { getFullUrl, setByDotNotation, truncateText } from '.';
 
 describe('utils', () => {
 
@@ -48,4 +48,22 @@ describe('utils', () => {
             expect(result).toBe('Lorem Ipsum is simply dummy text.');
         });
     });
+
+    describe('.getFullUrl', () => {
+        it('should not change the value', () => {
+            const envVariable = '{{endpointUrl}}';
+            const result = getFullUrl(envVariable);
+            expect(result).toBe(envVariable);
+        });
+        it('should not change the value', () => {
+            const url = 'https://test.com/grapqhl';
+            const result = getFullUrl(url);
+            expect(result).toBe(url);
+        });
+        it('should prepend text with origin location', () => {
+            const endpoint = 'grapqhl';
+            const result = getFullUrl(endpoint);
+            expect(result).toBe(location.origin + "/" + endpoint);
+        });
+    })
 })

--- a/packages/altair-app/src/app/modules/altair/utils/index.ts
+++ b/packages/altair-app/src/app/modules/altair/utils/index.ts
@@ -6,6 +6,7 @@ import isElectron from 'altair-graphql-core/build/utils/is_electron';
 import { debug } from './logger';
 import { IDictionary } from '../interfaces/shared';
 import fileDialog from 'file-dialog';
+import { VARIABLE_REGEX } from '../services/environment/environment.service';
 
 /**
  * Download the specified data with the provided options
@@ -166,8 +167,7 @@ export const getFullUrl = (url: string) => {
   }
 
   // regex to test if given string is an environment variable
-  const regex = /^{{[a-zA-Z._]+}}$/gm;
-  if (regex.test(url)) {
+  if (VARIABLE_REGEX.test(url)) {
     return url;
   }
 

--- a/packages/altair-app/src/app/modules/altair/utils/index.ts
+++ b/packages/altair-app/src/app/modules/altair/utils/index.ts
@@ -165,6 +165,12 @@ export const getFullUrl = (url: string) => {
     return url;
   }
 
+  // regex to test if given string is an environment variable
+  const regex = /^{{[a-zA-Z._]+}}$/gm;
+  if (regex.test(url)) {
+    return url;
+  }
+
   if (!validUrl.isUri(url)) {
     if (url.trim() === '*') {
       return location.href;


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
https://github.com/altair-graphql/altair/issues/1735

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->
Added a regex to test if given string is an environment variable. If so - pass it as is, thus fixing the mentioned issue.