### PR TITLE
Update egghead course url

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ For all contributions, please respect the following guidelines:
 - Do not commit changes to files that are irrelevant to your feature or bugfix (eg: `.gitignore`).
 - Be aware that the pull request review process is not immediate, and is generally proportional to the size of the pull request.
 
-Working on your first Pull Request? You can learn how from this free series, [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+Working on your first Pull Request? You can learn how from this free series, [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
 
 At this point, you're ready to make your changes! Feel free to ask for help; everyone is a beginner at first 😄.
 


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ x] Ran `yarn test-build`
- [ y] Updated relevant documentations
- [x ] Updated matching config options in altair-static

### Changes proposed in this pull request:
Updating egghead course url. existing url provided in documentation is returning 404 page not found error. 

refer to the screenshot below.

![notfound](https://user-images.githubusercontent.com/20293971/148767093-615401bf-a000-430a-be86-e6572631345c.PNG)

