### PR TITLE
feat: support csp for fastify plugin

### DIFF
--- a/packages/altair-fastify-plugin/src/index.ts
+++ b/packages/altair-fastify-plugin/src/index.ts
@@ -1,4 +1,4 @@
-import { getDistDirectory, renderAltair, RenderOptions } from 'altair-static';
+import { getDistDirectory, renderAltair, RenderOptions, renderInitialOptions } from 'altair-static';
 import fp from 'fastify-plugin';
 import fastifyStatic from 'fastify-static';
 
@@ -45,6 +45,15 @@ const fastifyAltairPlugin: FastifyPluginCallback<AltairFastifyPluginOptions> = (
   fastify.get(path, (_req, res) => {
     res.type('text/html').send(altairPage);
   });
+
+  if (renderOptions.serveInitialOptionsInSeperateRequest){
+    const initialOptions = renderInitialOptions(renderOptions);
+    const initOptPath = path + '/initial_options.js';
+
+    fastify.get(initOptPath, (_req, res) => {
+      res.type('application/javascript').send(initialOptions);
+    });
+  }
 
   done();
 };


### PR DESCRIPTION
Support content security policy that forbids inline scripts.

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
Added get endpoint to render `initial_options.js` when `serveInitialOptionsInSeperateRequest` is set to `true`