### PR TITLE
Add new scriptSrc for local files

### DIFF
--- a/packages/altair-electron/src/app/window.js
+++ b/packages/altair-electron/src/app/window.js
@@ -170,6 +170,7 @@ class WindowManager {
         `'${createSha256CspHash(renderInitialOptions())}'`,
         `https://cdn.jsdelivr.net`,
         `localhost:*`,
+        `file:`,
       ];
       callback({
         responseHeaders: Object.assign(


### PR DESCRIPTION
### Fixes #
[Bug: Local plugins get rejected by Content-Security-Policy](https://github.com/altair-graphql/altair/issues/1888)

### Checks

- [x] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
Adds allowed source to Script src for plugins that are loaded from a local folder through "file://[...]"