### PR TITLE
AppGet no longer exists 😢

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For windows users, you can install using [chocolatey](https://chocolatey.org/pac
 $ choco install altair-graphql
 ```
 
-Or [winget](https://winget.run/pkg/altair-graphql/altair)
+...or [winget](https://winget.run/pkg/altair-graphql/altair):
 
 ```
 $ winget install -e --id altair-graphql.altair

--- a/README.md
+++ b/README.md
@@ -94,13 +94,7 @@ For arch linux users, an AUR package [aur/altair](https://aur.archlinux.org/pack
 $ yay -S altair
 ```
 
-For windows users, you can install using [appget](https://appget.net/packages/i/altair-graphql):
-
-```
-$ appget install altair-graphql
-```
-
-or [chocolatey](https://chocolatey.org/packages/altair-graphql):
+For windows users, you can install using [chocolatey](https://chocolatey.org/packages/altair-graphql):
 
 ```
 $ choco install altair-graphql

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ For windows users, you can install using [chocolatey](https://chocolatey.org/pac
 $ choco install altair-graphql
 ```
 
+Or [winget](https://winget.run/pkg/altair-graphql/altair)
+
+```
+$ winget install -e --id altair-graphql.altair
+```
+
 ### Usage with express
 You can use altair with an express server using [altair-express-middleware](https://www.npmjs.com/package/altair-express-middleware). Read more about how to use this [here](packages/altair-express-middleware/README.md).
 


### PR DESCRIPTION
### Fixes #
No issue raised, but I note that AppGet no longer exists, thus may be removed from the install instructions. It still works with Chocolatey though.

### Checks
N/A

### Changes proposed in this pull request:
Only a change to the Readme