### PR TITLE
Add tests to subscription-url-dialog.component

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/subscription-url-dialog/subscription-url-dialog.component.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/components/subscription-url-dialog/subscription-url-dialog.component.spec.ts
@@ -9,6 +9,7 @@ import * as services from '../../services';
 import { SubscriptionUrlDialogComponent } from './subscription-url-dialog.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from '../../modules/shared/shared.module';
+import * as refreshEditor from '../../utils/codemirror/refresh-editor';
 
 describe('SubscriptionUrlDialogComponent', () => {
   let component: SubscriptionUrlDialogComponent;
@@ -34,7 +35,32 @@ describe('SubscriptionUrlDialogComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should call handleEditorRefresh after first change detection check', () => {
+    spyOn(refreshEditor, 'handleEditorRefresh');
+    fixture.detectChanges();
+
+    expect(refreshEditor.handleEditorRefresh).toHaveBeenCalled();
+  });
+
+  it("should handle subscriptionUrlChange", () => {
+    const subscriptionUrl = "test";
+    component.subscriptionUrl = subscriptionUrl;
+    component.subscriptionUrlChange.emit(subscriptionUrl);
+    expect(component.subscriptionUrl).toBe(subscriptionUrl);
+  });
+
+  it("should handle updateSubscriptionProviderId", () => {
+    spyOn(component.subscriptionProviderIdChange, "emit");
+
+    const providerId = "test";
+    component.updateSubscriptionProviderId(providerId);
+
+    expect(component.subscriptionProviderIdChange.emit).toHaveBeenCalledWith(
+      providerId
+    );
+  });
+
+  it("should create", () => {
     expect(component).toBeTruthy();
   });
 });


### PR DESCRIPTION
### Fixes #
Part of #1717

### Checks

- [x] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
This PR adds tests around the functionality of the `subscription-url-dialog.component`:

- handleEditorRefresh gets called on change detection
- subscriptionUrlChange
- updateSubscriptionProviderId