### PR TITLE
Added pre- and post-request scripts to collections

### DIFF
--- a/packages/altair-app/e2e/tsconfig.e2e.json
+++ b/packages/altair-app/e2e/tsconfig.e2e.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "target": "es2020",
     "types":[
-      "jasmine",
+      "jest",
       "node"
     ]
   }

--- a/packages/altair-app/src/app/modules/altair/altair.module.ts
+++ b/packages/altair-app/src/app/modules/altair/altair.module.ts
@@ -81,6 +81,7 @@ const providers = [
   services.ThemeRegistryService,
   services.SubscriptionProviderRegistryService,
   services.PluginContextService,
+  services.QueryService,
   // Setting the reducer provider in main.ts now (for proper config initialization)
   // reducerProvider,
   CookieService,

--- a/packages/altair-app/src/app/modules/altair/components/edit-collection-dialog/__snapshots__/edit-collection-dialog.component.spec.ts.snap
+++ b/packages/altair-app/src/app/modules/altair/components/edit-collection-dialog/__snapshots__/edit-collection-dialog.component.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditCollectionDialogComponent should render correctly 1`] = `
+<app-edit-collection-dialog>
+  <nz-modal />
+</app-edit-collection-dialog>
+`;

--- a/packages/altair-app/src/app/modules/altair/components/edit-collection-dialog/edit-collection-dialog.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/edit-collection-dialog/edit-collection-dialog.component.html
@@ -4,6 +4,7 @@
   [nzTitle]="modalTitle"
   [nzContent]="modalContent"
   [nzFooter]="modalFooter"
+  [nzWidth]="800"
   (nzOnCancel)="toggleDialogChange.next($event)"
 >
   <ng-template #modalTitle>
@@ -15,9 +16,33 @@
 
   <ng-template #modalContent>
     <div class="app-dialog-body" *ngIf="collection">
-      <div class="form-group">
-        {{ 'COLLECTION_TITLE_LABEL' | translate }}
-        <input type="text" class="dialog-input" [(ngModel)]="collection.title">
+      <div class="app-dialog-section">
+        <div class="form-group">
+          {{ 'COLLECTION_TITLE_LABEL' | translate }}
+          <input type="text" class="dialog-input" [(ngModel)]="title">
+        </div>
+      </div>
+      <div class="app-dialog-section">
+        <nz-tabset
+          [nzAnimated]="false"
+          nzSize="small"
+          nzTabBarGutter="16"
+        >
+          <nz-tab [nzTitle]="'PRE_REQUEST_TAB' | translate">
+            <app-pre-request-editor
+              [preRequest]="preRequest"
+              (preRequestScriptChange)="preRequest.script = $event"
+              (preRequestEnabledChange)="preRequest.enabled = $event"
+            ></app-pre-request-editor>
+          </nz-tab>
+          <nz-tab [nzTitle]="'POST_REQUEST_TAB' | translate">
+            <app-post-request-editor
+              [postRequest]="postRequest"
+              (postRequestScriptChange)="postRequest.script = $event"
+              (postRequestEnabledChange)="postRequest.enabled = $event"
+            ></app-post-request-editor>
+          </nz-tab>
+        </nz-tabset>
       </div>
     </div>
   </ng-template>

--- a/packages/altair-app/src/app/modules/altair/components/edit-collection-dialog/edit-collection-dialog.component.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/components/edit-collection-dialog/edit-collection-dialog.component.spec.ts
@@ -1,38 +1,31 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
-import { CodemirrorModule } from '@ctrl/ngx-codemirror';
-import { TranslateModule } from '@ngx-translate/core';
-
 import { EditCollectionDialogComponent } from './edit-collection-dialog.component';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from '../../modules/shared/shared.module';
+import { mount, NgxTestWrapper } from '../../../../../testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { expect, it } from '@jest/globals';
 
 describe('EditCollectionDialogComponent', () => {
-  let component: EditCollectionDialogComponent;
-  let fixture: ComponentFixture<EditCollectionDialogComponent>;
+  let wrapper: NgxTestWrapper<EditCollectionDialogComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [ EditCollectionDialogComponent ],
+  beforeEach(async() => {
+    wrapper = await mount({
+      component: EditCollectionDialogComponent,
+      declarations: [
+        EditCollectionDialogComponent,
+      ],
+      providers: [],
       imports: [
         BrowserAnimationsModule,
         FormsModule,
-        CodemirrorModule,
         SharedModule,
-        TranslateModule.forRoot()
       ],
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(EditCollectionDialogComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+      schemas: [ NO_ERRORS_SCHEMA ]
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should render correctly', () => {
+    expect(wrapper.component.nativeElement).toMatchSnapshot();
   });
 });

--- a/packages/altair-app/src/app/modules/altair/components/edit-collection-dialog/edit-collection-dialog.component.ts
+++ b/packages/altair-app/src/app/modules/altair/components/edit-collection-dialog/edit-collection-dialog.component.ts
@@ -1,12 +1,14 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { IQueryCollection } from 'altair-graphql-core/build/types/state/collection.interfaces';
+import { PostrequestState } from 'altair-graphql-core/build/types/state/postrequest.interfaces';
+import { PrerequestState } from 'altair-graphql-core/build/types/state/prerequest.interfaces';
 
 @Component({
   selector: 'app-edit-collection-dialog',
   templateUrl: './edit-collection-dialog.component.html',
   styleUrls: ['./edit-collection-dialog.component.scss']
 })
-export class EditCollectionDialogComponent  {
+export class EditCollectionDialogComponent implements OnChanges {
 
   @Input() showEditCollectionDialog = true;
   @Input() collection: IQueryCollection;
@@ -14,12 +16,28 @@ export class EditCollectionDialogComponent  {
   @Output() importCurlChange = new EventEmitter<string>();
   @Output() updateCollectionChange = new EventEmitter<{ collection: IQueryCollection }>();
 
-  constructor() { }
+  title = '';
+  preRequest: PrerequestState = { script: '', enabled: false };
+  postRequest: PostrequestState = { script: '', enabled: false };
 
-  
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.collection?.currentValue) {
+      const collection = changes.collection?.currentValue as IQueryCollection;
+      // setup form data fields
+      this.title = collection.title;
+      this.preRequest = collection.preRequest || { script: '', enabled: false };
+      this.postRequest = collection.postRequest || { script: '', enabled: false };
+    }
+  }
 
   updateCollection() {
+    const collection = {
+      ...this.collection,
+      title: this.title,
+      preRequest: this.preRequest,
+      postRequest: this.postRequest,
+    };
     this.toggleDialogChange.next(false);
-    this.updateCollectionChange.next({ collection: this.collection });
+    this.updateCollectionChange.next({ collection: collection });
   }
 }

--- a/packages/altair-app/src/app/modules/altair/components/settings-dialog/settings-dialog.component.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/components/settings-dialog/settings-dialog.component.spec.ts
@@ -35,7 +35,7 @@ describe('SettingsDialogComponent', () => {
       providers: [
         MockProviders(NotifyService),
         KeybinderService,
-        WindowService,
+        MockProviders(WindowService),
         DbService,
         ElectronAppService,
         ElectronService,

--- a/packages/altair-app/src/app/modules/altair/containers/window/window.component.ts
+++ b/packages/altair-app/src/app/modules/altair/containers/window/window.component.ts
@@ -221,32 +221,6 @@ export class WindowComponent implements OnInit {
       }
     });
 
-    // Validate that query is ACTUALLY in an existing collection
-    this.getWindowState().pipe(
-      untilDestroyed(this),
-      switchMap(data => {
-        if (data?.layout.collectionId && data?.layout.windowIdInCollection) {
-          return this.collections$.pipe(
-            map(collections => {
-              const collection = collections.find(collection => collection.id === data.layout.collectionId);
-
-              if (collection) {
-                const query = collection.queries.find(q => q.id === data.layout.windowIdInCollection);
-                return !!query;
-              }
-
-              return false;
-            }),
-          );
-        }
-
-        return EMPTY;
-      }),
-    ).subscribe(isValidCollectionQuery => {
-      if (!isValidCollectionQuery) {
-        this.store.dispatch(new layoutActions.SetWindowIdInCollectionAction(this.windowId, {}));
-      }
-    });
     this.windowService.setupWindow(this.windowId);
   }
 

--- a/packages/altair-app/src/app/modules/altair/effects/query-collection.effect.ts
+++ b/packages/altair-app/src/app/modules/altair/effects/query-collection.effect.ts
@@ -43,7 +43,15 @@ export class QueryCollectionEffects {
 
           return this.collectionService.create({
             title: res.action.payload.collectionTitle,
-            queries: [ query ]
+            queries: [ query ],
+            preRequest: {
+              script: '',
+              enabled: false,
+            },
+            postRequest: {
+              script: '',
+              enabled: false,
+            },
           }, res.action.payload.parentCollectionId);
         }),
         tap(() => this.notifyService.success('Created collection.')),

--- a/packages/altair-app/src/app/modules/altair/effects/query.effect.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/effects/query.effect.spec.ts
@@ -11,8 +11,8 @@ import {
   DonationService,
   EnvironmentService,
   ElectronAppService,
-  PreRequestService,
   SubscriptionProviderRegistryService,
+  QueryService,
 } from '../services';
 import * as fromRoot from '../store';
 import { ConvertToNamedQueryAction, SetQueryAction } from '../store/query/query.action';
@@ -26,7 +26,7 @@ describe('query effects', () => {
   let mockDonationService: DonationService;
   let mockElectronAppService: ElectronAppService;
   let mockEnvironmentService: EnvironmentService;
-  let mockPrerequestService: PreRequestService;
+  let mockQueryService: QueryService;
   let mockSubscriptionProviderRegistryService: SubscriptionProviderRegistryService;
   let mockStore: Store<RootState>;
 
@@ -38,7 +38,7 @@ describe('query effects', () => {
     mockDonationService = mock();
     mockElectronAppService = mock();
     mockEnvironmentService = mock();
-    mockPrerequestService = mock();
+    mockQueryService = mock();
     mockSubscriptionProviderRegistryService = mock();
     mockStore = mockStoreFactory();
   });
@@ -65,7 +65,7 @@ describe('query effects', () => {
         mockDonationService,
         mockElectronAppService,
         mockEnvironmentService,
-        mockPrerequestService,
+        mockQueryService,
         mockSubscriptionProviderRegistryService,
         mockStore,
       );

--- a/packages/altair-app/src/app/modules/altair/services/electron-app/electron-app.service.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/services/electron-app/electron-app.service.spec.ts
@@ -18,7 +18,7 @@ describe('ElectronAppService', () => {
       ],
       providers: [
         ElectronAppService,
-        WindowService,
+        MockProvider(WindowService),
         DbService,
         MockProvider(NotifyService),
         GqlService,

--- a/packages/altair-app/src/app/modules/altair/services/environment/environment.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/environment/environment.service.ts
@@ -60,7 +60,15 @@ export class EnvironmentService {
       }
     }
 
-    return merge(baseEnvironment, subEnvironment);
+    return this.mergeEnvironments(baseEnvironment, subEnvironment);
+  }
+
+  mergeWithActiveEnvironment(environment: IEnvironment) {
+    return this.mergeEnvironments(this.getActiveEnvironment(), environment);
+  }
+
+  mergeEnvironments(env1: IEnvironment, env2: IEnvironment) {
+    return merge(env1, env2);
   }
 
   /**

--- a/packages/altair-app/src/app/modules/altair/services/index.ts
+++ b/packages/altair-app/src/app/modules/altair/services/index.ts
@@ -15,3 +15,4 @@ export { PreRequestService } from './pre-request/pre-request.service';
 export { ThemeRegistryService } from './theme/theme-registry.service';
 export { SubscriptionProviderRegistryService } from './subscriptions/subscription-provider-registry.service';
 export { PluginContextService } from './plugin/context/plugin-context.service';
+export { QueryService } from './query/query.service';

--- a/packages/altair-app/src/app/modules/altair/services/keybinder/keybinder.service.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/services/keybinder/keybinder.service.spec.ts
@@ -20,7 +20,7 @@ describe('KeybinderService', () => {
       ],
       providers: [
         KeybinderService,
-        WindowService,
+        MockProvider(WindowService),
         DbService,
         ElectronAppService,
         ElectronService,

--- a/packages/altair-app/src/app/modules/altair/services/pre-request/pre-request.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/pre-request/pre-request.service.ts
@@ -139,6 +139,11 @@ export class PreRequestService {
         getEnvironment: (key: string) => {
           return data.environment[key];
         },
+        /**
+         * @param key environment key
+         * @param val value to set
+         * @param activeEnvironment if the value should be replaced in the currently active environment after execution
+         */
         setEnvironment: (key: string, val: any, activeEnvironment = false) => {
           data.environment[key] = val;
           if (activeEnvironment) {

--- a/packages/altair-app/src/app/modules/altair/services/query/query.service.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/services/query/query.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { MockProvider } from 'ng-mocks';
+import { mockStoreFactory } from '../../../../../testing';
+import { EnvironmentService } from '../environment/environment.service';
+import { NotifyService } from '../notify/notify.service';
+import { PreRequestService } from '../pre-request/pre-request.service';
+import { QueryCollectionService } from '../query-collection/query-collection.service';
+
+import { QueryService } from './query.service';
+
+describe('QueryService', () => {
+  let service: QueryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MockProvider(NotifyService),
+        MockProvider(EnvironmentService),
+        MockProvider(PreRequestService),
+        MockProvider(QueryCollectionService),
+        {
+          provide: Store,
+          useFactory: () => mockStoreFactory(),
+        },
+      ],
+    });
+    service = TestBed.inject(QueryService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/packages/altair-app/src/app/modules/altair/services/query/query.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/query/query.service.ts
@@ -1,0 +1,158 @@
+import { Injectable } from '@angular/core';
+import { select, Store } from '@ngrx/store';
+import * as fromRoot from '../../store';
+import { RootState } from 'altair-graphql-core/build/types/state/state.interfaces';
+import { debug } from '../../utils/logger';
+import { DbService } from '../db.service';
+import { DonationService } from '../donation.service';
+import { ElectronAppService } from '../electron-app/electron-app.service';
+import { EnvironmentService } from '../environment/environment.service';
+import { GqlService, SendRequestResponse } from '../gql/gql.service';
+import { NotifyService } from '../notify/notify.service';
+import { PreRequestService, RequestType, ScriptContextData } from '../pre-request/pre-request.service';
+import { SubscriptionProviderRegistryService } from '../subscriptions/subscription-provider-registry.service';
+import { first } from 'rxjs/operators';
+import { QueryCollectionService } from '../query-collection/query-collection.service';
+import { PerWindowState } from 'altair-graphql-core/build/types/state/per-window.interfaces';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class QueryService {
+
+  // TODO: Have a single method to hydrate all hydratables from the transformed data
+  constructor(
+    private notifyService: NotifyService,
+    private environmentService: EnvironmentService,
+    private preRequestService: PreRequestService,
+    private collectionService: QueryCollectionService,
+    private store: Store<RootState>
+  ) { }
+
+  async getWindowState(windowId: string) {
+    return this.store.pipe(select(fromRoot.selectWindowState(windowId))).pipe(first()).toPromise();
+  }
+
+  /**
+   * Gets pre-request transformed data when given script is executed
+   * @param windowId 
+   * @param script 
+   * @param preTransformedData 
+   */
+  async getPrerequestScriptTransformedDataForScript(windowId: string, script: string, preTransformedData?: ScriptContextData) {
+    const state = await this.getWindowState(windowId);
+    if (!state) {
+      return preTransformedData;
+    }
+
+    const query = (preTransformedData?.query || state.query.query || '').trim();
+    const headers = preTransformedData?.headers || state.headers;
+    const variables = preTransformedData?.variables || state.variables.variables;
+    const environment = this.environmentService.mergeWithActiveEnvironment(preTransformedData?.environment || {});
+
+    /**
+     * pre request execution context is passed the current headers, environment, variables, query, etc
+     * and returns a set of the same that would have potentially been modified during the script execution.
+     * The returned data is used instead of the original set of data
+     */
+    try {
+      const transformedData = await this.preRequestService.executeScript(script, {
+        environment,
+        headers,
+        query,
+        variables,
+      });
+
+      // merge preTransformedData with the new transformedData
+      return {
+        ...preTransformedData,
+        ...transformedData,
+      };
+    } catch (err) {
+      debug.error(err);
+      this.notifyService.error(err.message, 'Pre-request error');
+
+      return preTransformedData;
+    }
+  }
+
+  async getPrerequestTransformedData(windowId: string, preTransformedData?: ScriptContextData) {
+    const state = await this.getWindowState(windowId);
+    if (!state || !state.preRequest.enabled) {
+      return preTransformedData;
+    }
+
+    const collections = await this.getWindowParentCollections(state);
+    const collectionsWithEnabledPrerequests = collections.filter(collection => collection.preRequest?.enabled);
+
+    for (const collection of collectionsWithEnabledPrerequests) {
+      preTransformedData = await this.getPrerequestScriptTransformedDataForScript(windowId, collection.preRequest?.script || '', preTransformedData);
+    }
+
+    return this.getPrerequestScriptTransformedDataForScript(windowId, state.preRequest.script, preTransformedData);
+  }
+
+  async getPostRequestTransformedDataForScript(windowId: string, script: string, requestType: RequestType, data: SendRequestResponse, preTransformedData?: ScriptContextData) {
+    const state = await this.getWindowState(windowId);
+    if (!state) {
+      return preTransformedData;
+    }
+
+    const query = (preTransformedData?.query || state.query.query || '').trim();
+    const headers = preTransformedData?.headers || state.headers;
+    const variables = preTransformedData?.variables || state.variables.variables;
+    const environment = this.environmentService.mergeWithActiveEnvironment(preTransformedData?.environment || {});
+
+    try {
+      const transformedData = await this.preRequestService.executeScript(script, {
+        environment,
+        headers,
+        query,
+        variables,
+        requestType,
+        response: data,
+      });
+
+      // merge preTransformedData with the new transformedData
+      return {
+        ...preTransformedData,
+        ...transformedData,
+      };
+    } catch (err) {
+      debug.error(err);
+      this.notifyService.error(err.message, 'Post-request error');
+
+      return preTransformedData;
+    }
+  }
+
+  async getPostRequestTransformedData(windowId: string, requestType: RequestType, data: SendRequestResponse, preTransformedData?: ScriptContextData) {
+    const state = await this.getWindowState(windowId);
+    if (!state || !state.postRequest.enabled) {
+      return preTransformedData;
+    }
+
+    const collections = await this.getWindowParentCollections(state);
+    const collectionsWithEnabledPostrequests = collections.filter(collection => collection.postRequest?.enabled);
+
+    for (const collection of collectionsWithEnabledPostrequests) {
+      preTransformedData = await this.getPostRequestTransformedDataForScript(windowId, collection.postRequest?.script || '', requestType, data, preTransformedData);
+    }
+
+    return this.getPostRequestTransformedDataForScript(windowId, state.postRequest.script, requestType, data, preTransformedData);
+  }
+
+  private async getWindowParentCollections(window: PerWindowState) {
+    if (window.layout.windowIdInCollection && window.layout.collectionId) {
+      const collection = await this.collectionService.getCollectionByID(window.layout.collectionId);
+
+      if (collection) {
+        const collections = [ collection,  ...await this.collectionService.getAllParentCollections(collection) ];
+
+        return collections;
+      }
+    }
+
+    return [];
+  }
+}

--- a/packages/altair-app/src/app/modules/altair/services/window.service.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/services/window.service.spec.ts
@@ -10,6 +10,7 @@ import { GqlService } from './gql/gql.service';
 import { HttpClientModule } from '@angular/common/http';
 import { NotifyService } from './notify/notify.service';
 import { MockProvider } from 'ng-mocks';
+import { QueryCollectionService } from './query-collection/query-collection.service';
 
 describe('WindowService', () => {
   beforeEach(() => {
@@ -20,6 +21,7 @@ describe('WindowService', () => {
       providers: [
         WindowService,
         GqlService,
+        MockProvider(QueryCollectionService),
         MockProvider(NotifyService),
         services.DbService,
         { provide: Store, useValue: {

--- a/packages/altair-core/src/types/state/collection.interfaces.ts
+++ b/packages/altair-core/src/types/state/collection.interfaces.ts
@@ -1,3 +1,5 @@
+import { PostrequestState } from './postrequest.interfaces';
+import { PrerequestState } from './prerequest.interfaces';
 import { ExportWindowState } from './window.interfaces';
 
 export type SortByOptions = 'a-z' | 'z-a' | 'newest' | 'oldest';
@@ -21,6 +23,9 @@ export interface IQueryCollection {
   title: string;
   queries: IQuery[];
   description?: string;
+
+  preRequest?: PrerequestState;
+  postRequest?: PostrequestState;
 
   /**
    * path of the collection in the collection tree


### PR DESCRIPTION
The order of execution now is:
- collection pre request script
- (parent collections' pre request scripts)
- query pre request script
- send request/get response
- collection post request script
- (parent collections' post request scripts)
- query post request script

Created query service to contain complex query-related logic.

Closes #1763

### Checks

- [x] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->