### PR TITLE
Remove link to ARM mac download

### DIFF
--- a/site/src/index.md
+++ b/site/src/index.md
@@ -44,9 +44,6 @@ downloads:
     pattern: _x64_mac.dmg$
     link: https://github.com/altair-graphql/altair/releases/latest
     extra: brew install --cask altair-graphql-client
-  - name: macOS M1
-    image: /assets/img/osx_logo.svg
-    pattern: _arm64_mac.dmg$
   - name: linux
     image: /assets/img/linux_logo.svg
     pattern: AppImage


### PR DESCRIPTION
### Fixes #

No longer need this link as the homebrew download has a check for the architecture and downloads the right package
https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/altair-graphql-client.rb

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->