### PR TITLE
Fix proxy settings issue

### DIFF
--- a/packages/altair-electron/src/settings/renderer/app.js
+++ b/packages/altair-electron/src/settings/renderer/app.js
@@ -51,7 +51,7 @@ const hideAllNested = () => {
 // Initialize when loaded
 document.addEventListener('DOMContentLoaded', function () {
   // load settings
-  const initialData = ipc.sendSync(SETTINGS_STORE_EVENTS.GET_SETTINGS_DATA);
+  const initialData = ipc.sendSync(SETTINGS_STORE_EVENTS.GET_SETTINGS_DATA) || {};
   // set selected settings
   const networkForm = document.querySelector('.js-network-form');
   Object.keys(initialData).forEach((key) => {


### PR DESCRIPTION
Currently, there is a bug where it is impossible to set the proxy settings via the `Desktop Settings` menu. This is because `initialData` start as `undefined`, thus causing `Object.keys()` to throw an error and the rest of the initializer function never runs. This means that none of the save & submit functionality works because it never gets setup properly.

To fix this, you can just default `initialData` to an empty object.

### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->