### PR TITLE
The feature is better described as "tabs"

### DIFF
--- a/site/src/docs/features/multiple-tabs.md
+++ b/site/src/docs/features/multiple-tabs.md
@@ -1,0 +1,9 @@
+---
+parent: Features
+---
+
+# Multiple Tabs
+
+Altair provides the option to open multiple tabs each with a distinct state
+that is preserved across browser sessions. In addition, you can give each tab
+a custom name.

--- a/site/src/docs/features/multiple-windows.md
+++ b/site/src/docs/features/multiple-windows.md
@@ -1,9 +1,0 @@
----
-parent: Features
----
-
-# Multiple Windows
-
-Altair provides the option to open multiple windows each with a distinct state
-that is preserved across browser sessions. In addition, you can give each window
-a custom name.


### PR DESCRIPTION
* This is a documentation-only change *
All modern browsers have the concept of both tabs and windows. The feature in Altair called "windows" in the current documentation would be better described as "tabs".

### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks
* This is a documentation-only change *

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
Change the documentation so it refers to tabs, not windows.