### PR TITLE
adding the functionality for removing the show docs button when pressed

### DIFF
--- a/packages/altair-electron/src/app/touchbar.ts
+++ b/packages/altair-electron/src/app/touchbar.ts
@@ -20,7 +20,10 @@ export class TouchbarManager {
 
     const showDocsButton = new TouchBarButton({
       label: 'Show Docs',
-      click: () => this.actionManager.showDocs(),
+      click: () => {
+        this.actionManager.showDocs();
+        touchBar.escapeItem = spacer; // Set the escapeItem to spacer so the button disappears
+      },
     });
 
     const spacer = new TouchBarSpacer({
@@ -35,6 +38,7 @@ export class TouchbarManager {
         reloadDocsButton,
         showDocsButton,
       ],
+      escapeItem: showDocsButton, // Set the initial escapeItem to showDocsButton
     });
 
     return touchBar;


### PR DESCRIPTION
### Fixes #
The button(Showdocs) was still appearing even when opened


### Changes proposed in this pull request:
added escape item functionality to the touchbar for the showdocs button