### PR TITLE
#1645 - When the docs are shown, the Touch Bar should show a "Hide Docs" button

### DIFF
--- a/packages/altair-electron/e2e/app._spec.ts
+++ b/packages/altair-electron/e2e/app._spec.ts
@@ -76,6 +76,18 @@ const helpers = {
 
     return docViewer;
   },
+  async hideDocs(window: Page) {
+    const hideDocs = await window.$(
+      `${SELECTORS.VISIBLE_WINDOW} button[track-id="hide_docs"]`
+    );
+    await hideDocs.click();
+    const docViewer = await window.$(
+      `${SELECTORS.VISIBLE_WINDOW} .app-doc-viewer`
+    );
+    expect(await docViewer.isVisible()).toEqual(false);
+
+    return docViewer;
+  },
   async addHeader(window: Page, key: string, value: string) {
     const showHeaderElement = await window.$(
       '.side-menu-item[track-id="show_set_headers"]'

--- a/packages/altair-electron/src/app/actions.ts
+++ b/packages/altair-electron/src/app/actions.ts
@@ -40,6 +40,10 @@ export class ActionManager {
     this.windowInstance.webContents.send('show-docs', true);
   }
 
+  hideDocs() {
+    this.windowInstance.webContents.send('show-docs', false);
+  }
+
   showSettings() {
     this.windowInstance.webContents.send('show-settings', true);
   }

--- a/packages/altair-electron/src/app/touchbar.ts
+++ b/packages/altair-electron/src/app/touchbar.ts
@@ -1,10 +1,10 @@
-import { TouchBar } from 'electron';
+import { BrowserWindow, TouchBar } from 'electron';
 import { ActionManager } from './actions';
 
 const { TouchBarButton, TouchBarSpacer } = TouchBar;
 
 export class TouchbarManager {
-  constructor(private actionManager: ActionManager) {}
+  constructor(private actionManager: ActionManager, private windowInstance: BrowserWindow) {}
 
   createTouchBar() {
     const sendRequestButton = new TouchBarButton({
@@ -20,7 +20,14 @@ export class TouchbarManager {
 
     const showDocsButton = new TouchBarButton({
       label: 'Show Docs',
+      enabled: !this.windowInstance.webContents.showDocs,
       click: () => this.actionManager.showDocs(),
+    });
+
+    const hideDocsButton = new TouchBarButton({
+      label: 'Hide Docs',
+      enabled: this.windowInstance.webContents.showDocs,
+      click: () => this.actionManager.hideDocs(),
     });
 
     const spacer = new TouchBarSpacer({
@@ -34,6 +41,7 @@ export class TouchbarManager {
         spacer,
         reloadDocsButton,
         showDocsButton,
+        hideDocsButton,
       ],
     });
 


### PR DESCRIPTION
### Fixes #
#1645 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations (N/A)
- [ ] Updated matching config options in altair-static (N/A)

### Changes proposed in this pull request:
- Button added to touchbar to 'Hide Docs', should only be visible when docs are shown.
- 'Show Docs' button should only be visible when docs are not shown.