### PR TITLE
Add unit tests for API user service

### DIFF
--- a/packages/altair-api/custom-matchers.ts
+++ b/packages/altair-api/custom-matchers.ts
@@ -1,0 +1,136 @@
+function typeCheck(name: string, value: unknown, expectedType: string) {
+  const type = typeof value;
+  if (type != expectedType) {
+    return {
+      pass: false,
+      message: () =>
+        `expected ${name} (value: ${value}) to be ${expectedType}, but found ${type} instead.`,
+    };
+  }
+
+  return { pass: true, message: () => '' };
+}
+
+function toBeUser(user: any) {
+  let check = typeCheck('User.id', user?.id, 'string');
+  if (!check.pass) return check;
+
+  check = typeCheck('User.email', user?.email, 'string');
+  if (!check.pass) return check;
+
+  check = typeCheck('User.firstName', user?.firstName, 'string');
+  if (!check.pass) return check;
+
+  check = typeCheck('User.lastName', user?.lastName, 'string');
+  if (!check.pass) return check;
+
+  check = typeCheck('User.picture', user?.picture, 'string');
+  if (!check.pass) return check;
+
+  return {
+    pass: true,
+    message: () => `expected ${user} not to match the shape of a User object`,
+  };
+}
+
+function toBePlanConfig(planConfig: any) {
+  let check = typeCheck('PlanConfig.id', planConfig?.id, 'string');
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'PlanConfig.stripeProductId',
+    planConfig?.stripeProductId,
+    'string'
+  );
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'PlanConfig.maxQueryCount',
+    planConfig?.maxQueryCount,
+    'number'
+  );
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'PlanConfig.maxTeamCount',
+    planConfig?.maxTeamCount,
+    'number'
+  );
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'PlanConfig.maxTeamMemberCount',
+    planConfig?.maxTeamMemberCount,
+    'number'
+  );
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'PlanConfig.allowMoreTeamMembers',
+    planConfig?.allowMoreTeamMembers,
+    'boolean'
+  );
+  if (!check.pass) return check;
+
+  return {
+    pass: true,
+    message: () =>
+      `expected ${planConfig} not to match the shape of a PlanConfig object`,
+  };
+}
+
+function toBeSubscriptionItem(subItem: any) {
+  let check = typeCheck('SubscriptionItem.id', subItem?.id, 'string');
+  if (!check.pass) return check;
+
+  check = typeCheck('SubscriptionItem.object', subItem?.object, 'object');
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'SubscriptionItem.billing_thresholds',
+    subItem?.billing_thresholds,
+    'object'
+  );
+  if (!check.pass) return check;
+
+  check = typeCheck('SubscriptionItem.created', subItem?.created, 'number');
+  if (!check.pass) return check;
+
+  check = typeCheck('SubscriptionItem.metadata', subItem?.metadata, 'object');
+  if (!check.pass) return check;
+
+  check = typeCheck('SubscriptionItem.plan', subItem?.plan, 'object');
+  if (!check.pass) return check;
+
+  check = typeCheck('SubscriptionItem.price', subItem?.price, 'object');
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'SubscriptionItem.subscription',
+    subItem?.subscription,
+    'string'
+  );
+  if (!check.pass) return check;
+
+  check = typeCheck('SubscriptionItem.tax_rates', subItem?.tax_rates, 'object');
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'SubscriptionItem.lastResponse',
+    subItem?.lastResponse,
+    'object'
+  );
+  if (!check.pass) return check;
+
+  return {
+    pass: true,
+    message: () =>
+      `expected ${subItem} not to match the shape of a SubscriptionItem object`,
+  };
+}
+
+expect.extend({
+  toBeUser,
+  toBePlanConfig,
+  toBeSubscriptionItem,
+});

--- a/packages/altair-api/jest.config.js
+++ b/packages/altair-api/jest.config.js
@@ -12,4 +12,5 @@ module.exports = {
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
   testEnvironment: 'node',
+  setupFilesAfterEnv: ['./custom-matchers.ts'],
 };

--- a/packages/altair-api/jest.d.ts
+++ b/packages/altair-api/jest.d.ts
@@ -1,0 +1,7 @@
+declare namespace jest {
+  interface Matchers<R> {
+    toBeUser(): R;
+    toBePlanConfig(): R;
+    toBeSubscriptionItem(): R;
+  }
+}

--- a/packages/altair-api/src/auth/mocks/prisma-service.mock.ts
+++ b/packages/altair-api/src/auth/mocks/prisma-service.mock.ts
@@ -1,0 +1,40 @@
+import { PlanConfig, User, UserPlan } from '@altairgraphql/db';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
+
+export function mockUser(): User {
+  return {
+    id: 'f7102dc9-4c0c-42b4-9a17-e2bd4af94d5a',
+    stripeCustomerId: 'f7102dc9-4c0c-42b4-9a17-e2bd4af94d5a',
+    email: 'john.doe@email.com',
+    firstName: 'John',
+    lastName: 'Doe',
+    picture: 'asdf',
+  } as User;
+}
+
+export function mockUserPlan(): UserPlan {
+  return {
+    userId: 'f7102dc9-4c0c-42b4-9a17-e2bd4af94d5a',
+    planRole: 'my role',
+    quantity: 1,
+    planConfig: mockPlanConfig(),
+  } as UserPlan;
+}
+
+export function mockPlanConfig(): PlanConfig {
+  return {
+    id: 'f7102dc9-4c0c-42b4-9a17-e2bd4af94d5a',
+    stripeProductId: 'f7102dc9-4c0c-42b4-9a17-e2bd4af94d5a',
+    maxQueryCount: 1,
+    maxTeamCount: 1,
+    maxTeamMemberCount: 1,
+    allowMoreTeamMembers: false,
+  } as PlanConfig;
+}
+
+export function mockPrismaConflictError() {
+  return new PrismaClientKnownRequestError('User already exists', {
+    code: 'P2002',
+    clientVersion: '1.0.0',
+  });
+}

--- a/packages/altair-api/src/auth/mocks/stripe-service.mock.ts
+++ b/packages/altair-api/src/auth/mocks/stripe-service.mock.ts
@@ -1,0 +1,22 @@
+import Stripe from 'stripe';
+
+export function mockStripeCustomer(): Stripe.Customer {
+  return {
+    id: 'dad57297-637d-4598-862b-9dedd84121fe',
+  } as Stripe.Customer;
+}
+
+export function mockSubscriptionItem(): Stripe.Response<Stripe.SubscriptionItem> {
+  return {
+    id: 'f7102dc9-4c0c-42b4-9a17-e2bd4af94d5a',
+    object: {},
+    billing_thresholds: {},
+    created: 1,
+    metadata: {},
+    plan: {},
+    price: {},
+    subscription: 'my sub',
+    tax_rates: [],
+    lastResponse: {},
+  } as Stripe.Response<Stripe.SubscriptionItem>;
+}

--- a/packages/altair-api/src/auth/user/user.service.spec.ts
+++ b/packages/altair-api/src/auth/user/user.service.spec.ts
@@ -57,7 +57,7 @@ describe('UserService', () => {
       const user = await service.createUser(payloadMock);
 
       // THEN
-      (expect(user) as any).toBeUser();
+      expect(user).toBeUser();
     });
 
     it('should throw and exception if the email is already taken', () => {
@@ -97,7 +97,7 @@ describe('UserService', () => {
       const user = await service.mustGetUser(userMock.id);
 
       // THEN
-      (expect(user) as any).toBeUser();
+      expect(user).toBeUser();
     });
 
     it("should throw an error if the user can't be found", () => {
@@ -124,7 +124,7 @@ describe('UserService', () => {
       const planConfig = await service.getPlanConfig(user.id);
 
       // THEN
-      (expect(planConfig) as any).toBePlanConfig();
+      expect(planConfig).toBePlanConfig();
     });
 
     it('should return the the basic plan if no plan was found for the user', async () => {
@@ -141,7 +141,7 @@ describe('UserService', () => {
       const planConfig = await service.getPlanConfig(user.id);
 
       // THEN
-      (expect(planConfig) as any).toBePlanConfig();
+      expect(planConfig).toBePlanConfig();
     });
   });
 
@@ -179,7 +179,7 @@ describe('UserService', () => {
       );
 
       // THEN
-      (expect(subscriptionItem) as any).toBeSubscriptionItem();
+      expect(subscriptionItem).toBeSubscriptionItem();
     });
   });
 

--- a/packages/altair-api/src/auth/user/user.service.spec.ts
+++ b/packages/altair-api/src/auth/user/user.service.spec.ts
@@ -2,9 +2,23 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from 'nestjs-prisma';
 import { StripeService } from 'src/stripe/stripe.service';
 import { UserService } from './user.service';
+import { SignupInput } from '../models/signup.input';
+import {
+  mockPlanConfig,
+  mockPrismaConflictError,
+  mockUser,
+  mockUserPlan,
+} from '../mocks/prisma-service.mock';
+import {
+  mockStripeCustomer,
+  mockSubscriptionItem,
+} from '../mocks/stripe-service.mock';
+import Stripe from 'stripe';
 
 describe('UserService', () => {
   let service: UserService;
+  let stripeService: StripeService;
+  let prismaService: PrismaService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -12,9 +26,214 @@ describe('UserService', () => {
     }).compile();
 
     service = module.get<UserService>(UserService);
+    stripeService = module.get<StripeService>(StripeService);
+    prismaService = module.get<PrismaService>(PrismaService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('createUser', () => {
+    let payloadMock: SignupInput;
+
+    beforeAll(() => {
+      payloadMock = { email: 'john.doe@email.com' };
+    });
+
+    beforeEach(() => {
+      jest
+        .spyOn(stripeService, 'connectOrCreateCustomer')
+        .mockResolvedValueOnce(mockStripeCustomer());
+    });
+
+    it('should return the created user object', async () => {
+      // GIVEN
+      jest
+        .spyOn(prismaService.user, 'create')
+        .mockResolvedValueOnce(mockUser());
+
+      // WHEN
+      const user = await service.createUser(payloadMock);
+
+      // THEN
+      (expect(user) as any).toBeUser();
+    });
+
+    it('should throw and exception if the email is already taken', () => {
+      // GIVEN
+      jest
+        .spyOn(prismaService.user, 'create')
+        .mockRejectedValueOnce(mockPrismaConflictError());
+
+      // THEN
+      expect(service.createUser(payloadMock)).rejects.toThrow(
+        'Email john.doe@email.com already used.'
+      );
+    });
+
+    it('should rethrow an unknown error', () => {
+      // GIVEN
+      jest
+        .spyOn(prismaService.user, 'create')
+        .mockRejectedValueOnce(Error('Unexpected error'));
+
+      // THEN
+      expect(service.createUser(payloadMock)).rejects.toThrow(
+        'Unexpected error'
+      );
+    });
+  });
+
+  describe('mustGetUser', () => {
+    it('should return a user object', async () => {
+      // GIVEN
+      const userMock = mockUser();
+      jest
+        .spyOn(prismaService.user, 'findUnique')
+        .mockResolvedValueOnce(userMock);
+
+      // WHEN
+      const user = await service.mustGetUser(userMock.id);
+
+      // THEN
+      (expect(user) as any).toBeUser();
+    });
+
+    it("should throw an error if the user can't be found", () => {
+      // GIVEN
+      const user = mockUser();
+      jest.spyOn(prismaService.user, 'findUnique').mockResolvedValueOnce(null);
+
+      // THEN
+      expect(service.mustGetUser(user.id)).rejects.toThrow(
+        'User not found for id: f7102dc9-4c0c-42b4-9a17-e2bd4af94d5a'
+      );
+    });
+  });
+
+  describe('getPlanConfig', () => {
+    it('should return the plan config for the user', async () => {
+      // GIVEN
+      const user = mockUser();
+      jest
+        .spyOn(prismaService.userPlan, 'findUnique')
+        .mockResolvedValueOnce(mockUserPlan());
+
+      // WHEN
+      const planConfig = await service.getPlanConfig(user.id);
+
+      // THEN
+      (expect(planConfig) as any).toBePlanConfig();
+    });
+
+    it('should return the the basic plan if no plan was found for the user', async () => {
+      // GIVEN
+      const user = mockUser();
+      jest
+        .spyOn(prismaService.userPlan, 'findUnique')
+        .mockResolvedValueOnce(null);
+      jest
+        .spyOn(prismaService.planConfig, 'findUnique')
+        .mockResolvedValueOnce(mockPlanConfig());
+
+      // WHEN
+      const planConfig = await service.getPlanConfig(user.id);
+
+      // THEN
+      (expect(planConfig) as any).toBePlanConfig();
+    });
+  });
+
+  describe('updateSubscriptionQuantity', () => {
+    it("should throw an error if the user doesn't have a customer ID associated on Stripe", () => {
+      // GIVEN
+      const userMock = mockUser();
+      userMock.stripeCustomerId = undefined;
+      jest
+        .spyOn(prismaService.user, 'findUnique')
+        .mockResolvedValueOnce(userMock);
+
+      // THEN
+      expect(
+        service.updateSubscriptionQuantity(userMock.id, 1)
+      ).rejects.toThrow(
+        'Cannot update subscription quantity since user (f7102dc9-4c0c-42b4-9a17-e2bd4af94d5a) does not have a stripe customer ID'
+      );
+    });
+
+    it('should return the updated subscription item', async () => {
+      // GIVEN
+      const userMock = mockUser();
+      jest
+        .spyOn(prismaService.user, 'findUnique')
+        .mockResolvedValueOnce(userMock);
+      jest
+        .spyOn(stripeService, 'updateSubscriptionQuantity')
+        .mockResolvedValueOnce(mockSubscriptionItem());
+
+      // WHEN
+      const subscriptionItem = await service.updateSubscriptionQuantity(
+        userMock.id,
+        1
+      );
+
+      // THEN
+      (expect(subscriptionItem) as any).toBeSubscriptionItem();
+    });
+  });
+
+  describe('getStripeCustomerId', () => {
+    it('should return the stripe customer ID', () => {
+      // GIVEN
+      const userMock = mockUser();
+      jest
+        .spyOn(prismaService.user, 'findUnique')
+        .mockResolvedValueOnce(userMock);
+
+      // THEN
+      expect(service.getStripeCustomerId(userMock.id)).resolves.toEqual(
+        userMock.stripeCustomerId
+      );
+    });
+
+    it("should create a new customer entry on Stripe if the customer doesn't exist on Stripe yet", async () => {
+      // GIVEN
+      const userMock = mockUser();
+      jest
+        .spyOn(prismaService.user, 'findUnique')
+        .mockResolvedValueOnce({ ...userMock, stripeCustomerId: undefined });
+      jest
+        .spyOn(stripeService, 'connectOrCreateCustomer')
+        .mockResolvedValueOnce(mockStripeCustomer());
+      jest.spyOn(prismaService.user, 'update').mockImplementation(() => {
+        return null;
+      });
+
+      // THEN
+      expect(service.getStripeCustomerId(userMock.id)).resolves.toBe(
+        'dad57297-637d-4598-862b-9dedd84121fe'
+      );
+    });
+  });
+
+  describe('getBillingUrl', () => {
+    it('should return the persisted session URL', async () => {
+      // GIVEN
+      const userMock = mockUser();
+      const mockUrl = 'https://myurl.com/123';
+      jest
+        .spyOn(prismaService.user, 'findUnique')
+        .mockResolvedValueOnce(userMock);
+      jest.spyOn(stripeService, 'createBillingSession').mockResolvedValueOnce({
+        url: mockUrl,
+      } as Stripe.Response<Stripe.BillingPortal.Session>);
+
+      // WHEN
+      const url = await service.getBillingUrl(userMock.id, mockUrl);
+
+      // THEN
+      expect(url).toBe(mockUrl);
+    });
   });
 });


### PR DESCRIPTION
### Checks

- [x] Ran `yarn test-build`
- [x] Updated relevant documentations
- [x] Updated matching config options in altair-static

### Changes proposed in this pull request:
Added unit tests for all public method of altair-api/UserService that is not a proxy call.

Along with that, I added a couple of mocks and custom matches to make the test cases more readable.