### PR TITLE
Add remainder auth tests

### DIFF
--- a/packages/altair-api/custom-matchers.ts
+++ b/packages/altair-api/custom-matchers.ts
@@ -129,8 +129,76 @@ function toBeSubscriptionItem(subItem: any) {
   };
 }
 
+function toBePlan(plan: any) {
+  let check = typeCheck('Plan.id', plan?.id, 'string');
+  if (!check.pass) return check;
+
+  check = typeCheck('Plan.maxQueriesCount', plan?.maxQueriesCount, 'number');
+  if (!check.pass) return check;
+
+  check = typeCheck('Plan.maxTeamsCount', plan?.maxTeamsCount, 'number');
+  if (!check.pass) return check;
+
+  check = typeCheck('Plan.maxTeamsCount', plan?.maxTeamsCount, 'number');
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'Plan.maxTeamMembersCount',
+    plan?.maxTeamMembersCount,
+    'number'
+  );
+  if (!check.pass) return check;
+
+  check = typeCheck('Plan.canUpgradePro', plan?.canUpgradePro, 'boolean');
+  if (!check.pass) return check;
+
+  return {
+    pass: true,
+    message: () => `expected ${plan} not to match the shape of a Plan object`,
+  };
+}
+
+function toBeUserStats(stats: any) {
+  let check = typeCheck('UserStats.queries.own', stats?.queries?.own, 'number');
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'UserStats.queries.access',
+    stats?.queries?.access,
+    'number'
+  );
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'UserStats.collections.own',
+    stats?.collections?.own,
+    'number'
+  );
+  if (!check.pass) return check;
+
+  check = typeCheck(
+    'UserStats.collections.access',
+    stats?.collections?.access,
+    'number'
+  );
+  if (!check.pass) return check;
+
+  check = typeCheck('UserStats.teams.own', stats?.teams?.own, 'number');
+  if (!check.pass) return check;
+
+  check = typeCheck('UserStats.teams.access', stats?.teams?.access, 'number');
+  if (!check.pass) return check;
+
+  return {
+    pass: true,
+    message: () => `expected ${stats} not to match the shape of a Plan object`,
+  };
+}
+
 expect.extend({
   toBeUser,
   toBePlanConfig,
   toBeSubscriptionItem,
+  toBePlan,
+  toBeUserStats,
 });

--- a/packages/altair-api/custom-matchers.ts
+++ b/packages/altair-api/custom-matchers.ts
@@ -195,10 +195,24 @@ function toBeUserStats(stats: any) {
   };
 }
 
+function toBeBcryptHash(hash: string) {
+  const match = /^\$2b\$10\$.{53}$/.test(hash);
+
+  return {
+    pass: match,
+    message: () => {
+      return match
+        ? `expected ${hash} not to match the bcrypt hash format`
+        : `expected ${hash} to match the bcrypt hash format`;
+    },
+  };
+}
+
 expect.extend({
   toBeUser,
   toBePlanConfig,
   toBeSubscriptionItem,
   toBePlan,
   toBeUserStats,
+  toBeBcryptHash,
 });

--- a/packages/altair-api/jest.config.js
+++ b/packages/altair-api/jest.config.js
@@ -9,10 +9,7 @@ module.exports = {
   transform: {
     '^.+\\.(t|j)s$': 'ts-jest',
   },
-  collectCoverageFrom: [
-    'src/**/*.(t|j)s',
-    '!src/**/mocks/**',
-  ],
+  collectCoverageFrom: ['src/**/*.(t|j)s', '!src/**/mocks/**'],
   coverageDirectory: '../coverage',
   testEnvironment: 'node',
   setupFilesAfterEnv: ['./custom-matchers.ts'],

--- a/packages/altair-api/jest.d.ts
+++ b/packages/altair-api/jest.d.ts
@@ -3,5 +3,7 @@ declare namespace jest {
     toBeUser(): R;
     toBePlanConfig(): R;
     toBeSubscriptionItem(): R;
+    toBePlan(): R;
+    toBeUserStats(): R;
   }
 }

--- a/packages/altair-api/jest.d.ts
+++ b/packages/altair-api/jest.d.ts
@@ -5,5 +5,6 @@ declare namespace jest {
     toBeSubscriptionItem(): R;
     toBePlan(): R;
     toBeUserStats(): R;
+    toBeBcryptHash(): R;
   }
 }

--- a/packages/altair-api/src/auth/auth.controller.spec.ts
+++ b/packages/altair-api/src/auth/auth.controller.spec.ts
@@ -5,9 +5,19 @@ import { PrismaService } from 'nestjs-prisma';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { PasswordService } from './password/password.service';
+import { mockRequest, mockResponse } from './mocks/express.mock';
+import { mockUser } from './mocks/prisma-service.mock';
+import { User } from '@altairgraphql/db';
+import { IToken } from '@altairgraphql/api-utils';
+import { BadRequestException } from '@nestjs/common';
 
 describe('AuthController', () => {
   let controller: AuthController;
+  let authService: AuthService;
+
+  const tokenMock =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+  let authServiceReturnMock: User & { tokens: IToken };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,9 +32,127 @@ describe('AuthController', () => {
     }).compile();
 
     controller = module.get<AuthController>(AuthController);
+    authService = module.get<AuthService>(AuthService);
+
+    authServiceReturnMock = {
+      ...mockUser(),
+      tokens: {
+        accessToken: tokenMock,
+        refreshToken: tokenMock,
+      },
+    };
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('googleSigninCallback', () => {
+    it(`should redirect to the URL encoded in the state`, () => {
+      // GIVEN
+      const requestMock = mockRequest({
+        user: mockUser(),
+        query: {
+          state: 'https://google.com',
+        },
+      });
+      const responseMock = mockResponse({
+        redirect: jest.fn(),
+      });
+      jest
+        .spyOn(authService, 'googleLogin')
+        .mockReturnValueOnce(authServiceReturnMock);
+
+      // WHEN
+      controller.googleSigninCallback(requestMock, responseMock);
+
+      // THEN
+      expect(responseMock.redirect).toBeCalledWith(
+        'https://google.com/?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+      );
+    });
+
+    it(`should throw if the state can't be parsed to URL`, () => {
+      // GIVEN
+      const requestMock = mockRequest({
+        user: mockUser(),
+        query: {
+          state: 'hi',
+        },
+      });
+      const responseMock = mockResponse({
+        redirect: jest.fn(),
+      });
+      jest
+        .spyOn(authService, 'googleLogin')
+        .mockReturnValueOnce(authServiceReturnMock);
+
+      // THEN
+      expect(() =>
+        controller.googleSigninCallback(requestMock, responseMock)
+      ).toThrow(BadRequestException);
+    });
+
+    it(`should redirect to the product website if the state query param is not provided`, () => {
+      // GIVEN
+      const requestMock = mockRequest({
+        user: mockUser(),
+        query: {},
+      });
+      const responseMock = mockResponse({
+        redirect: jest.fn(),
+      });
+      jest
+        .spyOn(authService, 'googleLogin')
+        .mockReturnValueOnce(authServiceReturnMock);
+
+      // WHEN
+      controller.googleSigninCallback(requestMock, responseMock);
+
+      // THEN
+      expect(responseMock.redirect).toBeCalledWith('https://altairgraphql.dev');
+    });
+  });
+
+  describe('getUserProfile', () => {
+    it(`should return the user object from the service`, () => {
+      // GIVEN
+      const requestMock = mockRequest({ user: mockUser() });
+      jest
+        .spyOn(authService, 'googleLogin')
+        .mockReturnValueOnce(authServiceReturnMock);
+
+      // WHEN
+      const user = controller.getUserProfile(requestMock);
+
+      // THEN
+      expect(user).toBeUser();
+    });
+  });
+
+  describe('getShortlivedEventsToken', () => {
+    it(`should return a short lived token for the current user`, () => {
+      // GIVEN
+      const requestMock = mockRequest({ user: mockUser() });
+      jest
+        .spyOn(authService, 'getShortLivedEventsToken')
+        .mockReturnValueOnce(tokenMock);
+
+      // WHEN
+      const token = controller.getShortlivedEventsToken(requestMock);
+
+      // THEN
+      expect(token.slt).toEqual(tokenMock);
+    });
+
+    it(`should throw an error if the user ID is missing from the request`, () => {
+      // GIVEN
+      const requestMock = mockRequest();
+
+      // THEN
+      expect(() => controller.getShortlivedEventsToken(requestMock)).toThrow(
+        BadRequestException
+      );
+    });
   });
 });

--- a/packages/altair-api/src/auth/mocks/express.mock.ts
+++ b/packages/altair-api/src/auth/mocks/express.mock.ts
@@ -1,0 +1,9 @@
+import { Request, Response } from 'express';
+
+export function mockRequest(props?: object): Request {
+  return { ...props } as Request;
+}
+
+export function mockResponse(props?: object): Response {
+  return { ...props } as Response;
+}

--- a/packages/altair-api/src/auth/mocks/express.mock.ts
+++ b/packages/altair-api/src/auth/mocks/express.mock.ts
@@ -1,9 +1,9 @@
 import { Request, Response } from 'express';
 
-export function mockRequest(props?: object): Request {
+export function mockRequest(props?: Partial<Request>): Request {
   return { ...props } as Request;
 }
 
-export function mockResponse(props?: object): Response {
+export function mockResponse(props?: Partial<Response>): Response {
   return { ...props } as Response;
 }

--- a/packages/altair-api/src/auth/mocks/password.mock.ts
+++ b/packages/altair-api/src/auth/mocks/password.mock.ts
@@ -1,0 +1,9 @@
+export const passwordMock = '123456';
+export const otherPasswordMock = 'secret';
+
+export const passwordHashMapping = {
+  [passwordMock]:
+    '$2b$10$i.6ZxLRuMEZ3UvfCAjLsDO5RpJHOAwBWw.K9EDHxdYmrqNFeJ0kG2',
+  [otherPasswordMock]:
+    '$2b$10$0En78yD5TJvSoYLhf1vFNO4TxBa2Eyco0blVScDhf.9uGZ92zGTH.',
+};

--- a/packages/altair-api/src/auth/mocks/prisma-service.mock.ts
+++ b/packages/altair-api/src/auth/mocks/prisma-service.mock.ts
@@ -12,13 +12,13 @@ export function mockUser(): User {
   } as User;
 }
 
-export function mockUserPlan(): UserPlan {
+export function mockUserPlan(): UserPlan & { planConfig: PlanConfig } {
   return {
     userId: 'f7102dc9-4c0c-42b4-9a17-e2bd4af94d5a',
     planRole: 'my role',
     quantity: 1,
     planConfig: mockPlanConfig(),
-  } as UserPlan;
+  } as UserPlan & { planConfig: PlanConfig };
 }
 
 export function mockPlanConfig(): PlanConfig {

--- a/packages/altair-api/src/auth/mocks/stripe-service.mock.ts
+++ b/packages/altair-api/src/auth/mocks/stripe-service.mock.ts
@@ -1,3 +1,4 @@
+import { IPlanInfo } from '@altairgraphql/api-utils';
 import Stripe from 'stripe';
 
 export function mockStripeCustomer(): Stripe.Customer {
@@ -19,4 +20,10 @@ export function mockSubscriptionItem(): Stripe.Response<Stripe.SubscriptionItem>
     tax_rates: [],
     lastResponse: {},
   } as Stripe.Response<Stripe.SubscriptionItem>;
+}
+
+export function mockPlanInfo(): IPlanInfo {
+  return {
+    priceId: 'c444e512-4a6d-4b68-bb80-43c32edde415',
+  } as IPlanInfo;
 }

--- a/packages/altair-api/src/auth/password/password.service.spec.ts
+++ b/packages/altair-api/src/auth/password/password.service.spec.ts
@@ -1,9 +1,15 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PasswordService } from './password.service';
+import * as bcrypt from 'bcrypt';
 
 describe('PasswordService', () => {
   let service: PasswordService;
+  let configService: ConfigService;
+
+  const passwordMock = '123456';
+  const hashMock =
+    '8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -11,9 +17,72 @@ describe('PasswordService', () => {
     }).compile();
 
     service = module.get<PasswordService>(PasswordService);
+    configService = module.get<ConfigService>(ConfigService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('bcryptSaltRounds', () => {
+    it(`should return the salt rounds`, () => {
+      // GIVEN
+      jest
+        .spyOn(configService, 'get')
+        .mockReturnValueOnce({ bcryptSaltOrRound: 16 });
+
+      // WHEN
+      const rounds = service.bcryptSaltRounds;
+
+      // THEN
+      expect(rounds).toEqual(16);
+    });
+  });
+
+  describe('validatePassword', () => {
+    it(`should return true if the password matches the provided hash`, async () => {
+      // GIVEN
+      jest
+        .spyOn(bcrypt, 'compare')
+        .mockImplementationOnce(() => Promise.resolve(true));
+
+      // WHEN
+      const validationResult = await service.validatePassword(
+        passwordMock,
+        hashMock
+      );
+
+      // THEN
+      expect(validationResult).toBe(true);
+    });
+
+    it(`should return false if the password doesn't match the provided hash`, async () => {
+      // GIVEN
+      jest
+        .spyOn(bcrypt, 'compare')
+        .mockImplementationOnce(() => Promise.resolve(false));
+
+      // WHEN
+      const validationResult = await service.validatePassword(
+        passwordMock,
+        `${hashMock}-test`
+      );
+
+      // THEN
+      expect(validationResult).toBe(false);
+    });
+  });
+
+  describe('hashPassword', () => {
+    it(`should returned the hash of the password`, async () => {
+      // GIVEN
+      jest.spyOn(bcrypt, 'hash').mockImplementationOnce(() => hashMock);
+
+      // WHEN
+      const hash = await service.hashPassword(passwordMock);
+
+      // THEN
+      expect(hash).toEqual(hashMock);
+    });
   });
 });

--- a/packages/altair-api/src/auth/password/password.service.spec.ts
+++ b/packages/altair-api/src/auth/password/password.service.spec.ts
@@ -2,14 +2,15 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PasswordService } from './password.service';
 import * as bcrypt from 'bcrypt';
+import {
+  otherPasswordMock,
+  passwordHashMapping,
+  passwordMock,
+} from '../mocks/password.mock';
 
 describe('PasswordService', () => {
   let service: PasswordService;
   let configService: ConfigService;
-
-  const passwordMock = '123456';
-  const hashMock =
-    '8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -41,15 +42,10 @@ describe('PasswordService', () => {
 
   describe('validatePassword', () => {
     it(`should return true if the password matches the provided hash`, async () => {
-      // GIVEN
-      jest
-        .spyOn(bcrypt, 'compare')
-        .mockImplementationOnce(() => Promise.resolve(true));
-
       // WHEN
       const validationResult = await service.validatePassword(
         passwordMock,
-        hashMock
+        passwordHashMapping[passwordMock]
       );
 
       // THEN
@@ -57,15 +53,10 @@ describe('PasswordService', () => {
     });
 
     it(`should return false if the password doesn't match the provided hash`, async () => {
-      // GIVEN
-      jest
-        .spyOn(bcrypt, 'compare')
-        .mockImplementationOnce(() => Promise.resolve(false));
-
       // WHEN
       const validationResult = await service.validatePassword(
         passwordMock,
-        `${hashMock}-test`
+        passwordHashMapping[otherPasswordMock]
       );
 
       // THEN
@@ -75,14 +66,11 @@ describe('PasswordService', () => {
 
   describe('hashPassword', () => {
     it(`should returned the hash of the password`, async () => {
-      // GIVEN
-      jest.spyOn(bcrypt, 'hash').mockImplementationOnce(() => hashMock);
-
       // WHEN
-      const hash = await service.hashPassword(passwordMock);
+      const hash = await service.hashPassword(otherPasswordMock);
 
       // THEN
-      expect(hash).toEqual(hashMock);
+      expect(hash).toBeBcryptHash();
     });
   });
 });

--- a/packages/altair-api/src/auth/user/user.controller.spec.ts
+++ b/packages/altair-api/src/auth/user/user.controller.spec.ts
@@ -1,9 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { testProviders } from 'test/providers';
 import { UserController } from './user.controller';
+import { mockRequest } from '../mocks/express.mock';
+import { mockPlanConfig, mockUser } from '../mocks/prisma-service.mock';
+import { UserService } from './user.service';
+import { QueriesService } from '../../queries/queries.service';
+import { QueryCollectionsService } from '../../query-collections/query-collections.service';
+import { TeamsService } from '../../teams/teams.service';
 
 describe('UserController', () => {
   let controller: UserController;
+  let userService: UserService;
+  let queryService: QueriesService;
+  let collectionService: QueryCollectionsService;
+  let teamService: TeamsService;
+
+  const urlMock = 'https://altairgraphql.dev';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -12,9 +24,79 @@ describe('UserController', () => {
     }).compile();
 
     controller = module.get<UserController>(UserController);
+    userService = module.get<UserService>(UserService);
+    queryService = module.get<QueriesService>(QueriesService);
+    collectionService = module.get<QueryCollectionsService>(
+      QueryCollectionsService
+    );
+    teamService = module.get<TeamsService>(TeamsService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe(`getBillingUrl`, () => {
+    it(`should return a billing URL`, async () => {
+      // GIVEN
+      const requestMock = mockRequest({
+        user: mockUser(),
+        headers: { referer: 'https://altairgraphql.dev/billing' },
+      });
+      jest.spyOn(userService, 'getBillingUrl').mockResolvedValueOnce(urlMock);
+
+      // WHEN
+      const response = await controller.getBillingUrl(requestMock);
+
+      // THEN
+      expect(response.url).toBe(urlMock);
+    });
+  });
+
+  describe(`getCurrentPlan`, () => {
+    it(`should return a plan`, async () => {
+      // GIVEN
+      const requestMock = mockRequest({ user: mockUser() });
+      const planConfigMock = mockPlanConfig();
+      jest
+        .spyOn(userService, 'getPlanConfig')
+        .mockResolvedValueOnce(planConfigMock);
+
+      // WHEN
+      const response = await controller.getCurrentPlan(requestMock);
+
+      // THEN
+      expect(response).toBePlan();
+    });
+  });
+
+  describe(`getStats`, () => {
+    it(`should return user stats`, async () => {
+      // GIVEN
+      const requestMock = mockRequest({ user: mockUser() });
+      jest.spyOn(queryService, 'count').mockResolvedValue(42);
+      jest.spyOn(collectionService, 'count').mockResolvedValue(43);
+      jest.spyOn(teamService, 'count').mockResolvedValue(44);
+
+      // WHEN
+      const response = await controller.getStats(requestMock);
+
+      // THEN
+      expect(response).toBeUserStats();
+    });
+  });
+
+  describe(`getProPlanUrl`, () => {
+    it(`should return the pro URL`, async () => {
+      // GIVEN
+      const requestMock = mockRequest({ user: mockUser() });
+      jest.spyOn(userService, 'getProPlanUrl').mockResolvedValueOnce(urlMock);
+
+      // WHEN
+      const response = await controller.getProPlanUrl(requestMock);
+
+      // THEN
+      expect(response.url).toBe(urlMock);
+    });
   });
 });


### PR DESCRIPTION
### Fixes #
#1717 

### Checks

- [x] Ran `yarn test-build`
- [x] Updated relevant documentations
- [x] Updated matching config options in altair-static

### Changes proposed in this pull request:

Added unit tests for all public methods of:
- AuthController
- PasswordService
- UserController
- UserService

Add dynamic mocks for Express request and response.

Add custom matches for user controller responses.