### PR TITLE
Highlight only the relevant part instead of the whole text

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/settings-dialog/extensions.ts
+++ b/packages/altair-app/src/app/modules/altair/components/settings-dialog/extensions.ts
@@ -47,7 +47,6 @@ const settingsLintSource: LintSource = (view) => {
 
           const erroredValueBoundaries = findErrorValueBoundaries(text, error);
 
-          // TODO: Highlight only the relevant part instead of the whole text
           return {
             from: erroredValueBoundaries.start,
             to: erroredValueBoundaries.end,

--- a/packages/altair-app/src/app/modules/altair/utils/json.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/utils/json.spec.ts
@@ -1,0 +1,29 @@
+import { getValueBoundariesInStringifiedJson } from './json';
+
+describe('getValueBoundariesInStringifiedJson', () => {
+  it(`should return the boundaries of a numeric value`, () => {
+    // GIVEN
+    const json = `{\n  "theme": "system",\n  "language": "en-US",\n  "addQueryDepthLimit": 3,\n  "tabSize": 2\n}`;
+    const key = 'addQueryDepthLimit';
+
+    // WHEN
+    const boundaries = getValueBoundariesInStringifiedJson(json, key);
+
+    // THEN
+    expect(boundaries.start).toBe(70);
+    expect(boundaries.end).toBe(71);
+  });
+
+  it(`should return the boundaries of a string value`, () => {
+    // GIVEN
+    const json = `{\n  "theme": "system",\n  "language": "en-US",\n  "addQueryDepthLimit": 3,\n  "tabSize": 2\n}`;
+    const key = 'language';
+
+    // WHEN
+    const boundaries = getValueBoundariesInStringifiedJson(json, key);
+
+    // THEN
+    expect(boundaries.start).toBe(37);
+    expect(boundaries.end).toBe(44);
+  });
+});

--- a/packages/altair-app/src/app/modules/altair/utils/json.ts
+++ b/packages/altair-app/src/app/modules/altair/utils/json.ts
@@ -1,0 +1,17 @@
+type Boundaries = { start: number; end: number };
+
+export function getValueBoundariesInStringifiedJson(
+  json: string,
+  key: string
+): Boundaries {
+  const validValues = '[0-9]+|"(?:\\\\.|[^\\\\"])*"|true|false|null';
+  const matcher = new RegExp(`"${key}"\\s*:\\s*(${validValues}),?`);
+
+  const match = matcher.exec(json) as RegExpExecArray;
+  const matchedStr = match[1] as string;
+
+  return {
+    start: match.index + match[0].indexOf(matchedStr),
+    end: match.index + match[0].indexOf(matchedStr) + matchedStr.length,
+  };
+}


### PR DESCRIPTION
### Fixes #
#2052

### Checks

- [x] Ran `yarn test-build`
- [x] Updated relevant documentations
- [x] Updated matching config options in altair-static

### Changes proposed in this pull request:

Add a function that could return the offsets for a value of a key from a stringified JSON.

Apply it on the settings error highlight to only underline the errored values.