### PR TITLE
fix koa middleware dependencies

### DIFF
--- a/packages/altair-koa-middleware/package.json
+++ b/packages/altair-koa-middleware/package.json
@@ -22,7 +22,7 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
-    "@koa/router": "^12.0.1",
+    "@koa/router": "11 - 12",
     "koa-send": "^5.0.1"
   },
   "engines": {

--- a/packages/altair-koa-middleware/package.json
+++ b/packages/altair-koa-middleware/package.json
@@ -15,7 +15,6 @@
     "@types/supertest": "^2.0.11",
     "jest": "29.4.1",
     "koa": "^2.13.1",
-    "koa-send": "^5.0.1",
     "nodemon": "^2.0.12",
     "supertest": "^6.1.6",
     "ts-jest": "29.0.5",
@@ -23,7 +22,8 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
-    "@koa/router": "^12.0.1"
+    "@koa/router": "^12.0.1",
+    "koa-send": "^5.0.1"
   },
   "engines": {
     "node": ">= 12"


### PR DESCRIPTION
Following [this conversation](https://github.com/altair-graphql/altair/pull/2342/files#r1416581529), will create a patch fix and move koa-send from peer dependency in a latter v6 update.
cc @jaydenseric

### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->