### PR TITLE
fix fill all fields regression

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/query-editor/query-editor.component.ts
+++ b/packages/altair-app/src/app/modules/altair/components/query-editor/query-editor.component.ts
@@ -72,6 +72,7 @@ import { TODO } from 'altair-graphql-core/build/types/shared';
 import { PrerequestState } from 'altair-graphql-core/build/types/state/prerequest.interfaces';
 import { PostrequestState } from 'altair-graphql-core/build/types/state/postrequest.interfaces';
 import { getInitialState } from '../../store/variables/variables.reducer';
+import { getTokenAtPosition } from 'graphql-language-service';
 
 const AUTOCOMPLETE_CHARS = /^[a-zA-Z0-9_@(]$/;
 
@@ -588,8 +589,11 @@ export class QueryEditorComponent implements OnInit, AfterViewInit, OnChanges {
             }
           });
         },
-        onFillAllFields: (view, schema, query, cursor, token) => {
+        onFillAllFields: (view, schema, query, cursor, _token) => {
           this.zone.run(() => {
+            // the token from cm6-graphql is currently not working properly (offending PR https://github.com/graphql/graphiql/pull/3149).
+            // so we generate the token from graphql-language-service ourselves with the right offset instead
+            const token = getTokenAtPosition(query, cursor, 1);
             const updatedQuery = this.gqlService.fillAllFields(
               schema,
               query,

--- a/packages/altair-app/src/app/modules/altair/services/gql/__snapshots__/fillFields.spec.ts.snap
+++ b/packages/altair-app/src/app/modules/altair/services/gql/__snapshots__/fillFields.spec.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fillAllFields generates expected query 1`] = `
+{
+  "insertions": [
+    {
+      "index": 20,
+      "string": " {
+    id
+    url
+    name
+    authors
+    characters {
+      id
+      book
+      url
+      name
+      gender
+      culture
+      born
+      died
+      titles
+      aliases
+      father
+      mother
+      spouse
+      allegiances
+      books
+      playedBy
+    }
+    released
+  }",
+    },
+  ],
+  "result": "{
+  hello
+  GOTBooks {
+    id
+    url
+    name
+    authors
+    characters {
+      id
+      book
+      url
+      name
+      gender
+      culture
+      born
+      died
+      titles
+      aliases
+      father
+      mother
+      spouse
+      allegiances
+      books
+      playedBy
+    }
+    released
+  } 
+}",
+}
+`;

--- a/packages/altair-app/src/app/modules/altair/services/gql/fillFields.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/services/gql/fillFields.spec.ts
@@ -1,0 +1,22 @@
+import { Position } from 'cm6-graphql';
+import { ContextToken, getTokenAtPosition } from 'graphql-language-service';
+import { fillAllFields } from './fillFields';
+import { getTestSchema } from './test-helper';
+
+const testQuery = `{
+  hello
+  GOTBooks {
+  }
+}`;
+describe('fillAllFields', () => {
+  it('generates expected query', () => {
+    const schema = getTestSchema();
+    const pos = new Position(2, 12);
+    const token = getTokenAtPosition(testQuery, pos, 1);
+    // expect(token).toBe('');
+    const res = fillAllFields(schema, testQuery, pos, token, {
+      maxDepth: 2,
+    });
+    expect(res).toMatchSnapshot();
+  });
+});

--- a/packages/altair-app/src/app/modules/altair/services/gql/fillFields.ts
+++ b/packages/altair-app/src/app/modules/altair/services/gql/fillFields.ts
@@ -1,7 +1,6 @@
 import { visit, print, TypeInfo, parse, GraphQLSchema, Kind } from 'graphql';
 import { debug } from '../../utils/logger';
 import getTypeInfo from 'codemirror-graphql/utils/getTypeInfo';
-import { Token } from 'codemirror';
 import { ContextToken } from 'graphql-language-service';
 import { buildSelectionSet } from './generateQuery';
 import { Position } from '../../utils/editor/helpers';

--- a/packages/altair-app/src/app/modules/altair/services/gql/test-helper.ts
+++ b/packages/altair-app/src/app/modules/altair/services/gql/test-helper.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+import { buildSchema } from 'graphql';
+import { resolve } from 'path';
+
+export const getTestSchema = () => {
+  const sdl = readFileSync(
+    resolve(__dirname, '../../../../../../fixtures/test.sdl'),
+    'utf8'
+  );
+  return buildSchema(sdl);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -17928,7 +17928,7 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
-http-errors@^1.6.3, http-errors@^1.7.3, http-errors@~1.8.0:
+http-errors@^1.6.3, http-errors@~1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
   integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
@@ -20415,15 +20415,6 @@ koa-convert@^2.0.0:
   dependencies:
     co "^4.6.0"
     koa-compose "^4.1.0"
-
-koa-send@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/koa-send/-/koa-send-5.0.1.tgz#39dceebfafb395d0d60beaffba3a70b4f543fe79"
-  integrity sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==
-  dependencies:
-    debug "^4.1.1"
-    http-errors "^1.7.3"
-    resolve-path "^1.4.0"
 
 koa@^2.13.1:
   version "2.13.4"
@@ -23794,7 +23785,7 @@ path-exists@^5.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
   integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
-path-is-absolute@1.0.1, path-is-absolute@^1.0.0:
+path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
@@ -25840,14 +25831,6 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-
-resolve-path@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
-  integrity sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==
-  dependencies:
-    http-errors "~1.6.2"
-    path-is-absolute "1.0.1"
 
 resolve-url-loader@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
We recently updated cm6-graphql and graphql-language-service packages. The upgrade of graphql-language-service introduced a regression to the fillAllFields logic. Narrowed it down to [this change](https://github.com/graphql/graphiql/pull/3149).

For now I'm ignoring the token from cm6-graphql and generating it here until we fix it upstream in cm6-graphql.

### Fixes #
<!-- Mention the issues this PR addresses -->
#2349 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->