### PR TITLE
Removed unsafe-inline from extension CSP

### DIFF
--- a/cwex.yml
+++ b/cwex.yml
@@ -24,8 +24,9 @@ manifestOptions:
     - tabs
     - storage
     - notifications
-  # this CSP has been modified to allow unsafe-inline and unsafe-eval but the CSP in the index.html remains strict. This allows the web worker to have the less strict CSP.
-  content_security_policy: "script-src 'self' 'sha256-765ndVO8s0mJNdlCDVQJVuWyBpugFWusu1COU8BNbI8=' 'sha256-kFTKSG2YSVB69S6DWzferO6LmwbqfHmYBTqvVbPEp4I=' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://apis.google.com https://www.gstatic.com/ https://*.firebaseio.com https://www.googleapis.com localhost:* http://localhost:8002 http://localhost:8080; object-src 'self';"
+  # this CSP has been modified to allow unsafe-eval but the CSP in the index.html remains strict. This allows the web worker to have the less strict CSP.
+  # Note: firefox ignores the CSP if it contains unsafe-inline
+  content_security_policy: "script-src 'self' 'sha256-765ndVO8s0mJNdlCDVQJVuWyBpugFWusu1COU8BNbI8=' 'sha256-kFTKSG2YSVB69S6DWzferO6LmwbqfHmYBTqvVbPEp4I=' 'unsafe-eval' https://cdn.jsdelivr.net https://apis.google.com https://www.gstatic.com/ https://*.firebaseio.com https://www.googleapis.com localhost:* http://localhost:8002 http://localhost:8080; object-src 'self';"
   background:
     scripts:
       - js/background.js


### PR DESCRIPTION
Mozilla ignores the CSP of the extension if it contains `unsafe-inline`, and it doesn't show any warnings either making this difficult to spot. I've verified that the pre request script still works without `unsafe-inline`.

### Fixes #
<!-- Mention the issues this PR addresses -->
#2358 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->