### PR TITLE
Feat: Highlight Query Not Saved Changes

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/url-box/url-box.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/url-box/url-box.component.html
@@ -68,6 +68,7 @@
       nzTrigger="click"
       [nzDropdownMenu]="urlBoxActionMenu"
       class="url-box__button"
+      [ngClass]="{ 'url-box__button--not-saved': showQueryChanged }"
       >
       <app-icon name="save"></app-icon>
     </button>

--- a/packages/altair-app/src/app/modules/altair/components/url-box/url-box.component.ts
+++ b/packages/altair-app/src/app/modules/altair/components/url-box/url-box.component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { IQueryCollection } from 'altair-graphql-core/build/types/state/collection.interfaces';
 import { HTTP_VERBS } from 'altair-graphql-core/build/types/state/query.interfaces';
 import { OperationDefinitionNode } from 'graphql';
-import { VARIABLE_REGEX } from '../../services/environment/environment.service';
 import { BATCHED_REQUESTS_OPERATION } from '../../services/gql/gql.service';
 
 @Component({
@@ -15,6 +14,7 @@ export class UrlBoxComponent {
   @Input() isSubscribed = false;
   @Input() isLoading = false;
   @Input() showDocs = false;
+  @Input() showQueryChanged = false;
   @Input() selectedOperation = '';
   @Input() queryOperations: OperationDefinitionNode[] = [];
   @Input() streamState = '';

--- a/packages/altair-app/src/app/modules/altair/containers/window/window.component.html
+++ b/packages/altair-app/src/app/modules/altair/containers/window/window.component.html
@@ -9,6 +9,7 @@
     [isSubscribed]="isSubscribed$ | async"
     [isLoading]="(layout$ | async)?.isLoading"
     [showDocs]="showDocs$ | async"
+    [showQueryChanged]="queryMisMatchQueryInCollection$ | async"
     [selectedOperation]="selectedOperation$ | async"
     [queryOperations]="queryOperations$ | async"
     [streamState]="streamState$ | async"

--- a/packages/altair-app/src/app/modules/altair/containers/window/window.component.ts
+++ b/packages/altair-app/src/app/modules/altair/containers/window/window.component.ts
@@ -251,9 +251,9 @@ export class WindowComponent implements OnInit {
 
     this.queryMisMatchQueryInCollection$ = this.query$.pipe(
       withLatestFrom(this.currentCollection$),
-      map((res) => {
-        const currentQueryContent = res[0].query;
-        const queryInCollection = res[1]?.queries.find(
+      map(([currentQuery, currentCollection]) => {
+        const currentQueryContent = currentQuery.query;
+        const queryInCollection = currentCollection?.queries.find(
           (q) => q.id === this.queryIdInCollectionQueries
         )?.query;
         if (!(currentQueryContent && queryInCollection)) {

--- a/packages/altair-app/src/scss/components/_url-box.scss
+++ b/packages/altair-app/src/scss/components/_url-box.scss
@@ -103,6 +103,15 @@ app-url-box {
     background: rgba(var(--rgb-primary), 0.15);
     color: var(--primary-color);
   }
+
+  &--not-saved {
+    color: var(--tertiary-color);
+
+    &:hover {
+      background: rgba(var(--rgb-tertiary), 0.15);
+      color: var(--tertiary-color);
+    }
+  }
 }
 
 .url-box__method-wrapper {


### PR DESCRIPTION
### Fixes 
[#2425](https://github.com/altair-graphql/altair/issues/2425)


### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
- Added logic to check if query editor content does not match the query saved in the collection.
- If not matching, highlight the Save Button in a different color.

<img width="1162" alt="image" src="https://github.com/altair-graphql/altair/assets/18086061/b86f39ff-8440-446d-a709-187f169bce92">
