### PR TITLE
Add operationName to ScriptContextData

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/post-request-editor/post-request-editor.component.ts
+++ b/packages/altair-app/src/app/modules/altair/components/post-request-editor/post-request-editor.component.ts
@@ -25,6 +25,7 @@ export class PostRequestEditorComponent {
       {
         headers: [],
         environment: {},
+        operationName: '',
         query: '',
         variables: '',
       },

--- a/packages/altair-app/src/app/modules/altair/components/pre-request-editor/pre-request-editor.component.ts
+++ b/packages/altair-app/src/app/modules/altair/components/pre-request-editor/pre-request-editor.component.ts
@@ -25,6 +25,7 @@ export class PreRequestEditorComponent {
       {
         headers: [],
         environment: {},
+        operationName: '',
         query: '',
         variables: '',
       },

--- a/packages/altair-app/src/app/modules/altair/services/pre-request/helpers.ts
+++ b/packages/altair-app/src/app/modules/altair/services/pre-request/helpers.ts
@@ -24,6 +24,7 @@ export interface ScriptContextStorage {
 export interface ScriptContextData {
   headers: HeaderState;
   variables: string;
+  operationName: string;
   query: string;
   environment: IDictionary;
   requestScriptLogs?: LogLine[];

--- a/packages/altair-app/src/app/modules/altair/services/pre-request/pre-request.service.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/services/pre-request/pre-request.service.spec.ts
@@ -53,6 +53,7 @@ describe('PreRequestService', () => {
       const result = await service.executeScript(script, {
         environment: {},
         headers: [],
+        operationName: '',
         query: '',
         variables: '',
       });
@@ -60,6 +61,7 @@ describe('PreRequestService', () => {
       expect(result).toEqual({
         environment: {},
         headers: [],
+        operationName: '',
         query: '',
         variables: '',
       });
@@ -75,6 +77,7 @@ describe('PreRequestService', () => {
       const result = await service.executeScript(script, {
         environment: {},
         headers: [],
+        operationName: '',
         query: '',
         variables: '',
       });
@@ -84,6 +87,7 @@ describe('PreRequestService', () => {
           first: true,
         },
         headers: [],
+        operationName: '',
         query: '',
         variables: '',
       });
@@ -102,6 +106,7 @@ describe('PreRequestService', () => {
         const result = await service.executeScript(script, {
           environment: {},
           headers: [],
+          operationName: '',
           query: '',
           variables: '',
         });
@@ -112,6 +117,7 @@ describe('PreRequestService', () => {
             encoded: 'Zmlyc3Q=',
           },
           headers: [],
+          operationName: '',
           query: '',
           variables: '',
         });
@@ -129,6 +135,7 @@ describe('PreRequestService', () => {
         const result = await service.executeScript(script, {
           environment: {},
           headers: [],
+          operationName: '',
           query: '',
           variables: '',
         });
@@ -139,6 +146,7 @@ describe('PreRequestService', () => {
             decoded: 'first',
           },
           headers: [],
+          operationName: '',
           query: '',
           variables: '',
         });
@@ -156,6 +164,7 @@ describe('PreRequestService', () => {
         const result = await service.executeScript(script, {
           environment: {},
           headers: [],
+          operationName: '',
           query: '',
           variables: '',
         });
@@ -166,6 +175,7 @@ describe('PreRequestService', () => {
             sha: 'a7937b64b8caa58f03721bb6bacf5c78cb235febe0e70b1b84cd99541461a08e',
           },
           headers: [],
+          operationName: '',
           query: '',
           variables: '',
         });

--- a/packages/altair-app/src/app/modules/altair/services/query/query.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/query/query.service.ts
@@ -49,6 +49,7 @@ export class QueryService {
     }
 
     const query = (preTransformedData?.query || state.query.query || '').trim();
+    const operationName = (state.query.selectedOperation || '').trim();
     const headers = preTransformedData?.headers || state.headers;
     const variables =
       preTransformedData?.variables || state.variables.variables;
@@ -67,6 +68,7 @@ export class QueryService {
         {
           environment,
           headers,
+          operationName,
           query,
           variables,
         }
@@ -128,6 +130,7 @@ export class QueryService {
     }
 
     const query = (preTransformedData?.query || state.query.query || '').trim();
+    const operationName = (state.query.selectedOperation || '').trim();
     const headers = preTransformedData?.headers || state.headers;
     const variables =
       preTransformedData?.variables || state.variables.variables;
@@ -141,6 +144,7 @@ export class QueryService {
         {
           environment,
           headers,
+          operationName,
           query,
           variables,
           requestType,

--- a/packages/altair-docs/docs/features/prerequest-scripts.md
+++ b/packages/altair-docs/docs/features/prerequest-scripts.md
@@ -39,6 +39,8 @@ This contains data used to process your GraphQL request.
 
 **`altair.data.query`** - The GraphQL query sent to the server.
 
+**`altair.data.operationName`** - The GraphQL query operation name sent to the server.
+
 **`altair.data.environment`** - The formatted environment object containing the serialized set of environment data before your request is sent.
 
 ### altair.helpers
@@ -116,7 +118,6 @@ const token = await altair.storage.get("token");
 altair.helpers.setEnvironment('token_env', token);
 // You can use the environment variables in Altair after setting it by following this blog post: https://sirmuel.design/altair-becomes-environment-friendly-%EF%B8%8F-f9b4e9ef887c
 ```
-
 
 ### altair.response (Available in post request script)
 


### PR DESCRIPTION
### Fixes #
https://github.com/altair-graphql/altair/issues/2463

### Checks

- [x] Ran `yarn test-build`
- [x] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
This change adds `operationName` string field to the `ScriptContextData` object. The value is populated from the global state (`state.query.selectedOperation`). 

This value is then available through `altair.data` helper object in pre/post-request context.

Docs have been updated to mention the newly available field.