### PR TITLE
added v3 plugin system based on iframes

### DIFF
--- a/packages/altair-app/.eslintrc.js
+++ b/packages/altair-app/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
         ],
         'prettier/prettier': 0,
         'require-await': 'off',
-        '@typescript-eslint/require-await': 'warn',
+        '@typescript-eslint/require-await': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-empty-function': 'warn',
         '@typescript-eslint/no-var-requires': 'warn',

--- a/packages/altair-app/src/app/modules/altair/services/plugin/context/plugin-context.service.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/services/plugin/context/plugin-context.service.spec.ts
@@ -12,11 +12,11 @@ import { PluginEventService } from '../plugin-event.service';
 import { NotifyService } from '../../../services/notify/notify.service';
 import { SubscriptionProviderRegistryService } from '../../subscriptions/subscription-provider-registry.service';
 import { RootState } from 'altair-graphql-core/build/types/state/state.interfaces';
-import { AltairPlugin } from 'altair-graphql-core/build/plugin/plugin.interfaces';
+import { AltairV1Plugin } from 'altair-graphql-core/build/plugin/plugin.interfaces';
 
 const createContext = () => {
   const service: PluginContextService = TestBed.inject(PluginContextService);
-  const testPlugin: AltairPlugin = {
+  const testPlugin: AltairV1Plugin = {
     name: 'Test',
     display_name: 'Test plugin',
     capabilities: [],
@@ -29,7 +29,7 @@ const createContext = () => {
       version: '0.0.1',
     },
   };
-  return service.createContext('test-plugin', testPlugin);
+  return service.createV1Context('test-plugin', testPlugin);
 };
 
 describe('PluginContextService', () => {
@@ -65,7 +65,7 @@ describe('PluginContextService', () => {
           provide: PluginEventService,
           useFactory: () =>
             mock<PluginEventService>({
-              group: () => ({} as unknown as any),
+              group: () => ({}) as unknown as any,
             }),
         },
         {

--- a/packages/altair-app/src/app/modules/altair/services/pre-request/evaluator-client.factory.ts
+++ b/packages/altair-app/src/app/modules/altair/services/pre-request/evaluator-client.factory.ts
@@ -15,7 +15,7 @@ export class EvaluatorFrameClient extends ScriptEvaluatorClient {
   );
   private iframe = this.createIframe();
 
-  createIframe() {
+  private createIframe() {
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
     const sandboxUrl = new URL(this.config.sandboxUrl);
@@ -61,6 +61,7 @@ export class EvaluatorFrameClient extends ScriptEvaluatorClient {
     this.iframe.remove();
   }
 }
+
 export class EvaluatorClientFactory implements ScriptEvaluatorClientFactory {
   create() {
     if (document.baseURI && new URL(document.baseURI).origin === window.origin) {

--- a/packages/altair-app/src/app/modules/altair/store/local/local.action.ts
+++ b/packages/altair-app/src/app/modules/altair/store/local/local.action.ts
@@ -1,7 +1,10 @@
 import { Action as NGRXAction } from '@ngrx/store';
 import { AltairPanel } from 'altair-graphql-core/build/plugin/panel';
 import { AltairUiAction } from 'altair-graphql-core/build/plugin/ui-action';
-import { PluginStateEntry } from 'altair-graphql-core/build/types/state/local.interfaces';
+import {
+  V1PluginStateEntry,
+  V3PluginStateEntry,
+} from 'altair-graphql-core/build/types/state/local.interfaces';
 import { PerWindowState } from 'altair-graphql-core/build/types/state/per-window.interfaces';
 
 export const PUSH_CLOSED_WINDOW_TO_LOCAL = 'PUSH_CLOSED_WINDOW_TO_LOCAL';
@@ -27,7 +30,7 @@ export class PopFromClosedWindowsAction implements NGRXAction {
 export class AddInstalledPluginEntryAction implements NGRXAction {
   readonly type = ADD_INSTALLED_PLUGIN_ENTRY;
 
-  constructor(public payload: PluginStateEntry) {}
+  constructor(public payload: V1PluginStateEntry | V3PluginStateEntry) {}
 }
 
 export class SetPluginActiveAction implements NGRXAction {

--- a/packages/altair-app/src/scss/components/_editor.scss
+++ b/packages/altair-app/src/scss/components/_editor.scss
@@ -213,6 +213,8 @@ app-query-result {
   bottom: 10px;
   right: 10px;
   z-index: 3;
+  display: flex;
+  gap: 5px;
 }
 
 .subscription-result {

--- a/packages/altair-core/src/evaluator/events.ts
+++ b/packages/altair-core/src/evaluator/events.ts
@@ -1,0 +1,4 @@
+export const EVALUATOR_READY = 'evaluator::ready';
+export const EVALUATOR_INIT_EXECUTE = 'init_execute';
+export const getResponseEvent = <T extends string>(type: T) => `${type}_response`;
+export const getErrorEvent = <T extends string>(type: T) => `${type}_error`;

--- a/packages/altair-core/src/evaluator/worker.ts
+++ b/packages/altair-core/src/evaluator/worker.ts
@@ -1,0 +1,73 @@
+import { v4 as uuid } from 'uuid';
+import { getErrorEvent, getResponseEvent } from './events';
+export interface EventData<T extends string, P = unknown> {
+  type: T;
+  payload: P;
+}
+export abstract class EvaluatorWorker {
+  abstract onMessage<T extends string, P = unknown>(
+    handler: (e: EventData<T, P>) => void
+  ): void;
+  abstract send<T extends string>(type: T, payload?: unknown): void;
+  abstract onError(handler: (err: unknown) => void): void;
+  abstract destroy(): void;
+
+  subscribe<T extends string, P = unknown>(
+    type: T,
+    handler: (type: T, e: EventData<T, P>) => void
+  ): void {
+    this.onMessage((e: EventData<T, P>) => {
+      // Handle script events
+      if (e.type === type) {
+        handler(type, e);
+      }
+    });
+  }
+
+  request<T extends string, R = unknown>(
+    type: T,
+    ...args: unknown[]
+  ): Promise<R | undefined> {
+    return new Promise<R | undefined>((resolve, reject) => {
+      const id = uuid();
+      // TODO: cleanup listener
+      this.onMessage<string, { id: string; response?: R; error?: unknown }>((e) => {
+        switch (e.type) {
+          case getResponseEvent(type): {
+            if (e.payload.id !== id) {
+              return;
+            }
+            return resolve(e.payload.response);
+          }
+          case getErrorEvent(type): {
+            if (e.payload.id !== id) {
+              return;
+            }
+            return reject(e.payload.error);
+          }
+        }
+      });
+      this.send(type, { id, args });
+    });
+  }
+
+  respond<T extends string, R = unknown>(
+    type: T,
+    handler: (...args: unknown[]) => Promise<R>
+  ): void {
+    this.subscribe<T, { id: string; args: unknown[] }>(type, async (type, e) => {
+      // TODO: handle cancelling requests
+      // TODO: allow for multiple responses, or a single response
+      const { id, args } = e.payload;
+      try {
+        const res = await handler(...args);
+        this.send(getResponseEvent(type), { id, response: res });
+      } catch (err) {
+        this.send(getErrorEvent(type), {
+          id,
+          error: `${(err as any).message ?? err}`,
+        });
+      }
+    });
+  }
+}

--- a/packages/altair-core/src/plugin/context/context.interface.ts
+++ b/packages/altair-core/src/plugin/context/context.interface.ts
@@ -3,7 +3,7 @@ import { ICustomTheme } from '../../theme';
 import { ExportWindowState } from '../../types/state/window.interfaces';
 import { PluginEvent, PluginEventCallback } from '../event/event.interfaces';
 import { AltairPanel, AltairPanelLocation } from '../panel';
-import { AltairPlugin } from '../plugin.interfaces';
+import { AltairV1Plugin } from '../plugin.interfaces';
 import { AltairUiAction, AltairUiActionLocation } from '../ui-action';
 
 export interface CreatePanelOptions {
@@ -46,10 +46,7 @@ export interface PluginContext {
      *
      * returns panel instance (includes destroy() method)
      */
-    createPanel(
-      element: HTMLElement,
-      options?: CreatePanelOptions
-    ): AltairPanel;
+    createPanel(element: HTMLElement, options?: CreatePanelOptions): AltairPanel;
     destroyPanel(panel: AltairPanel): void;
 
     /**
@@ -88,5 +85,5 @@ export interface PluginContext {
 }
 
 export interface PluginContextGenerator {
-  createContext(pluginName: string, plugin: AltairPlugin): PluginContext;
+  createV1Context(pluginName: string, plugin: AltairV1Plugin): PluginContext;
 }

--- a/packages/altair-core/src/plugin/panel.ts
+++ b/packages/altair-core/src/plugin/panel.ts
@@ -1,4 +1,5 @@
 import { v4 as uuid } from 'uuid';
+import { PluginParentEngine } from './v3/parent-engine';
 
 export enum AltairPanelLocation {
   HEADER = 'header',
@@ -16,7 +17,9 @@ export class AltairPanel {
   constructor(
     public title: string,
     public element: HTMLElement,
-    public location: AltairPanelLocation
+    public location: AltairPanelLocation,
+    // TODO: Making this optional for now for backward compatibility. This should be required for v3 plugins.
+    public engine?: PluginParentEngine
   ) {}
 
   destroy() {

--- a/packages/altair-core/src/plugin/plugin.interfaces.ts
+++ b/packages/altair-core/src/plugin/plugin.interfaces.ts
@@ -35,7 +35,7 @@ export type PluginCapabilities =
  */
 export interface PluginManifest {
   // Version of manifest. Should be 1 or 2.
-  manifest_version: number;
+  manifest_version: 1 | 2;
   name: string;
   display_name: string;
   version: string;
@@ -50,7 +50,7 @@ export interface PluginManifest {
   capabilities?: PluginCapabilities[];
 }
 
-export interface AltairPlugin {
+export interface AltairV1Plugin {
   name: string;
   display_name: string;
   capabilities: PluginCapabilities[];
@@ -59,10 +59,10 @@ export interface AltairPlugin {
   manifest: PluginManifest;
 }
 
-export const createPlugin = (
+export const createV1Plugin = (
   name: string,
   manifest: PluginManifest
-): AltairPlugin => {
+): AltairV1Plugin => {
   return {
     name,
     manifest,

--- a/packages/altair-core/src/plugin/v3/capabilities.ts
+++ b/packages/altair-core/src/plugin/v3/capabilities.ts
@@ -1,0 +1,12 @@
+/**
+ * Specifies the capabilities (functionalities) available to the plugin.
+ * In the future, this would be used to request the necessary permissions from the user.
+ */
+export type PluginCapabilities =
+  | 'query:read'
+  | 'query:write'
+  | 'header:read'
+  | 'header:write'
+  | 'environment:read'
+  | 'environment:write';
+  

--- a/packages/altair-core/src/plugin/v3/context.ts
+++ b/packages/altair-core/src/plugin/v3/context.ts
@@ -1,0 +1,110 @@
+import { ICustomTheme } from '../../theme';
+import { ExportWindowState } from '../../types/state/window.interfaces';
+import {
+  CreateActionOptions,
+  CreatePanelOptions,
+  PluginWindowState,
+} from '../context/context.interface';
+import { PluginEvent, PluginEventCallback } from '../event/event.interfaces';
+
+export interface PluginV3Context {
+  /**
+   * Returns data about a window (tab) in the app
+   */
+  getWindowState(windowId: string): Promise<PluginWindowState | undefined>;
+
+  /**
+   * Returns data about the current window (tab) in the app
+   */
+  getCurrentWindowState(): Promise<PluginWindowState | undefined>;
+
+  /**
+   * Create an AltairPanel instance for displaying content in the app based on the panel name.
+   * The panel names are defined in the plugin options when the plugin is initialized.
+   *
+   * This returns the unique id of the panel.
+   */
+  // TODO: improve the type checking for the panelName based on the plugin options
+  // TODO: https://www.basedash.com/blog/typescript-object-with-dynamic-keys
+  // TODO: https://github.com/whatwg/html/issues/5484#issuecomment-620481794
+  createPanel(
+    panelName: string,
+    options?: CreatePanelOptions
+  ): Promise<string | undefined>;
+
+  /**
+   * Destroy a panel based on its unique id
+   */
+  destroyPanel(panelId: string): Promise<void>;
+
+  /**
+   * Adds a button in the app to perform an action.
+   * The action is defined by the plugin and is executed when the button is clicked.
+   *
+   * This returns the unique id of the action.
+   */
+  createAction(options: CreateActionOptions): Promise<string | undefined>;
+
+  /**
+   * Destroy an action based on its unique id
+   */
+  destroyAction(actionId: string): Promise<void>;
+
+  /**
+   * Check if the app is running in an Electron environment
+   */
+  isElectron(): Promise<boolean>;
+
+  /**
+   * Create a new window in the app with the given data
+   */
+  createWindow(data: ExportWindowState): Promise<void>;
+
+  /**
+   * Set the query in the app for the given window
+   */
+  setQuery(windowId: string, query: string): Promise<void>;
+
+  /**
+   * Set the variables in the app for the given window
+   */
+  setVariables(windowId: string, variables: string): Promise<void>;
+
+  /**
+   * Add a header in the app for the given window
+   */
+  setHeader(windowId: string, key: string, value: string): Promise<void>;
+
+  /**
+   * Set the endpoint in the app for the given window
+   */
+  setEndpoint(windowId: string, url: string): Promise<void>;
+
+  // TODO:
+  // addSubscriptionProvider(providerData: SubscriptionProviderData): void;
+
+  /**
+   * Subscribe to an event in the app
+   */
+  on<E extends PluginEvent>(
+    event: E,
+    callback: PluginEventCallback<E>
+  ): {
+    unsubscribe: () => void;
+  };
+
+  /**
+   * Remove all the event listeners
+   */
+  off(): void;
+
+  /**
+   * Add a custom theme to the app
+   */
+  addTheme(name: string, theme: ICustomTheme): Promise<void>;
+
+  /**
+   * Enable a theme in the app
+   */
+  enableTheme(name: string, darkMode?: boolean): Promise<void>;
+}

--- a/packages/altair-core/src/plugin/v3/events.ts
+++ b/packages/altair-core/src/plugin/v3/events.ts
@@ -1,0 +1,5 @@
+export const PLUGIN_ENGINE_READY = 'plugin-engine::ready';
+export const PLUGIN_SUBSCRIBE_TO_EVENT = 'plugin::subscribe_to_event';
+export const PLUGIN_CREATE_ACTION_EVENT = 'plugin::create_action';
+export const PLUGIN_GET_APP_STYLE_URL_EVENT = 'plugin::get_app_style_url';
+export const getActionEvent = (actionId: string) => `action::${actionId}`;

--- a/packages/altair-core/src/plugin/v3/frame-engine.ts
+++ b/packages/altair-core/src/plugin/v3/frame-engine.ts
@@ -1,0 +1,155 @@
+import { v4 as uuid } from 'uuid';
+import { PluginV3Context } from './context';
+import {
+  PLUGIN_CREATE_ACTION_EVENT,
+  PLUGIN_ENGINE_READY,
+  PLUGIN_GET_APP_STYLE_URL_EVENT,
+  PLUGIN_SUBSCRIBE_TO_EVENT,
+  getActionEvent,
+} from './events';
+import { PluginFrameWorker, instanceTypes } from './frame-worker';
+import { PluginV3Options } from './plugin';
+import { PluginWindowState } from '../context/context.interface';
+
+export class PluginFrameEngine {
+  private readyPromise: Promise<void>;
+  private eventListeners: Record<string, Function[]> = {};
+  private ctx?: PluginV3Context;
+
+  constructor(
+    private worker: PluginFrameWorker,
+    private options: PluginV3Options
+  ) {
+    this.readyPromise = new Promise((resolve) => {
+      this.worker.subscribe(PLUGIN_ENGINE_READY, () => {
+        resolve();
+      });
+    });
+
+    // check if this is a panel frame so we can handle the panel logic specially
+    const panelName = worker.getParams().panelName;
+    if (worker.getInstanceType() === instanceTypes.PANEL && panelName) {
+      this.handlePanelSetup(panelName);
+    }
+
+    // TODO: Pass the panels list to the parent engine for validation, in case the plugin tries to create a panel that doesn't exist
+
+    // TODO: skip the main frame only events if the frame is not the main frame
+  }
+
+  async ready() {
+    await this.readyPromise;
+  }
+
+  canInitialize() {
+    return this.worker.getInstanceType() === instanceTypes.MAIN;
+  }
+
+  private createContext(): PluginV3Context {
+    const ctx: PluginV3Context = {
+      getWindowState: (...args) => {
+        return this.worker.request('getWindowState', ...args);
+      },
+      getCurrentWindowState: (...args) => {
+        return this.worker.request('getCurrentWindowState', ...args);
+      },
+      createPanel: async (...args) => {
+        return this.worker.request('createPanel', ...args);
+      },
+      destroyPanel: async (...args) => {
+        return this.worker.request('destroyPanel', ...args);
+      },
+      createAction: async (opts) => {
+        // send action event to the parent engine without callback
+        // subscribe to the action event from the parent engine
+        const optsWithoutExecute = { ...opts, execute: undefined };
+        const idPromise: ReturnType<PluginV3Context['createAction']> =
+          this.worker.request(PLUGIN_CREATE_ACTION_EVENT, optsWithoutExecute);
+        const id = await idPromise;
+        if (id) {
+          this.worker.respond(getActionEvent(id), async (data) => {
+            opts.execute(data as PluginWindowState);
+          });
+        }
+        return id;
+      },
+      destroyAction: async (...args) => {
+        return this.worker.request('destroyAction', ...args);
+      },
+      isElectron: async (...args) => {
+        return !!(await this.worker.request('isElectron', ...args));
+      },
+      createWindow: (...args) => {
+        return this.worker.request('createWindow', ...args);
+      },
+      setQuery: (...args) => {
+        return this.worker.request('setQuery', ...args);
+      },
+      setVariables: (...args) => {
+        return this.worker.request('setVariables', ...args);
+      },
+      setHeader: (...args) => {
+        return this.worker.request('setHeader', ...args);
+      },
+      setEndpoint: (...args) => {
+        return this.worker.request('setEndpoint', ...args);
+      },
+      on: (event, callback) => {
+        this.worker.request(PLUGIN_SUBSCRIBE_TO_EVENT, event);
+        this.eventListeners[event] = this.eventListeners[event] || [];
+        const listeners = this.eventListeners[event];
+        if (listeners) {
+          listeners.push(callback);
+        }
+        this.worker.respond(event, async (...args) => {
+          const listeners = this.eventListeners[event];
+          if (!listeners) {
+            return;
+          }
+          listeners.forEach((listener) => listener(...args));
+        });
+
+        return {
+          unsubscribe: () => {
+            this.eventListeners[event] = (this.eventListeners[event] ?? []).filter(
+              (listener) => listener !== callback
+            );
+          },
+        };
+      },
+      off: () => {
+        this.eventListeners = {};
+        this.worker.request('off');
+      },
+      addTheme: (...args) => {
+        return this.worker.request('addTheme', ...args);
+      },
+      enableTheme: (...args) => {
+        return this.worker.request('enableTheme', ...args);
+      },
+    };
+
+    this.ctx = ctx;
+
+    return ctx;
+  }
+
+  getContext() {
+    if (!this.ctx) {
+      return this.createContext();
+    }
+    return this.ctx;
+  }
+
+  private async handlePanelSetup(panelName: string) {
+    const panel = this.options.panels[panelName];
+
+    if (panel) {
+      // setup styles in the panel
+      panel.initialize(
+        this.getContext(),
+        await this.worker.request(PLUGIN_GET_APP_STYLE_URL_EVENT)
+      );
+    }
+  }
+}

--- a/packages/altair-core/src/plugin/v3/frame-worker.ts
+++ b/packages/altair-core/src/plugin/v3/frame-worker.ts
@@ -1,0 +1,76 @@
+import { EvaluatorWorker, EventData } from '../../evaluator/worker';
+
+export const instanceTypes = {
+  MAIN: 'main',
+  PANEL: 'panel',
+} as const;
+export type InstanceType = (typeof instanceTypes)[keyof typeof instanceTypes];
+
+export interface FrameQueryParams {
+  sc: string;
+  id: string;
+  instanceType: InstanceType;
+  [key: string]: string;
+}
+export class PluginFrameWorker extends EvaluatorWorker {
+  private origin: string;
+  private id: string;
+  private instanceType: InstanceType = instanceTypes.MAIN;
+  private params: FrameQueryParams;
+
+  constructor() {
+    super();
+    const params: FrameQueryParams = Object.fromEntries(
+      new URLSearchParams(window.location.search)
+    ) as FrameQueryParams;
+    this.params = params;
+    // Get the source origin that embeds the iframe from the URL query parameter
+
+    if (!params.sc) {
+      throw new Error('Invalid source provided!');
+    }
+    if (!params.id) {
+      throw new Error('Invalid plugin ID provided!');
+    }
+
+    this.origin = params.sc;
+    this.id = params.id;
+    this.instanceType = params.instanceType ?? instanceTypes.MAIN;
+  }
+
+  getInstanceType() {
+    return this.instanceType;
+  }
+
+  getParams() {
+    return this.params;
+  }
+
+  onMessage<T extends string, P = unknown>(
+    handler: (e: EventData<T, P>) => void
+  ): void {
+    window.addEventListener('message', (e) => {
+      if (e.origin !== this.origin) {
+        return;
+      }
+      handler(e.data);
+    });
+  }
+
+  send(type: string, payload: any): void {
+    window.parent.postMessage({ type, payload }, this.origin);
+  }
+
+  onError(handler: (err: any) => void): void {
+    window.addEventListener('error', handler);
+    window.addEventListener('unhandledrejection', (e) => {
+      e.preventDefault();
+      handler(e.reason);
+    });
+  }
+
+  destroy(): void {
+    // cleanup resources
+    window.close();
+  }
+}

--- a/packages/altair-core/src/plugin/v3/manifest.ts
+++ b/packages/altair-core/src/plugin/v3/manifest.ts
@@ -1,0 +1,55 @@
+import { PluginCapabilities } from './capabilities';
+
+// support html and js entry points
+// js entry points will mean we create a new iframe and load the js file in it
+interface PluginEntry {
+  type: 'html';
+  path: string;
+}
+
+export interface PluginV3Manifest {
+  /**
+   * Version of manifest (should be 3)
+   */
+  manifest_version: 3;
+
+  /**
+   * Name of the plugin
+   */
+  name: string;
+
+  /**
+   * Display name of the plugin
+   */
+  display_name: string;
+
+  /**
+   * Version of the plugin
+   */
+  version: string;
+
+  /**
+   * Description of the plugin
+   */
+  description: string;
+
+  /**
+   * The entry point of the plugin
+   */
+  entry: PluginEntry;
+
+  /**
+   * capabilities of the plugin
+   */
+  capabilities?: PluginCapabilities[];
+
+  /**
+   * Email of the author of the plugin
+   */
+  author_email?: string;
+
+  /**
+   * Name of the author of the plugin
+   */
+  author?: string;
+}

--- a/packages/altair-core/src/plugin/v3/panel.ts
+++ b/packages/altair-core/src/plugin/v3/panel.ts
@@ -1,0 +1,53 @@
+import { PluginV3Context } from './context';
+
+interface StylesData {
+  styleUrls: string[];
+  styles: string[];
+  htmlClasses: string[];
+}
+export abstract class AltairV3Panel {
+  abstract create(ctx: PluginV3Context, container: HTMLElement): void;
+
+  initialize(ctx: PluginV3Context, data?: StylesData) {
+    if (data) {
+      this.setupStyles(data);
+    }
+
+    // Initialize the panel
+    const div = document.createElement('div');
+    div.id = 'altair-plugin-panel';
+    document.body.appendChild(div);
+    this.create(ctx, div);
+  }
+
+  private setupStyles(data: StylesData) {
+    // Get the CSS style URL from the app and apply it to the panel
+    data.styleUrls.forEach((styleUrl) => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+
+      link.href = styleUrl;
+      document.head.appendChild(link);
+    });
+
+    this.injectCSS(data.styles.join('\n'));
+
+    // set the background color of the panel to the theme background color
+    this.injectCSS(`
+      body {
+        background: transparent;
+      }
+    `);
+
+    data.htmlClasses.forEach((htmlClass) => {
+      document.documentElement.classList.add(htmlClass);
+    });
+  }
+
+  private injectCSS(css: string) {
+    let el = document.createElement('style');
+    el.innerText = css;
+    document.head.appendChild(el);
+    return el;
+  }
+}

--- a/packages/altair-core/src/plugin/v3/parent-engine.ts
+++ b/packages/altair-core/src/plugin/v3/parent-engine.ts
@@ -1,0 +1,139 @@
+import { CreateActionOptions } from '../context/context.interface';
+import { PluginEventPayloadMap } from '../event/event.interfaces';
+import { PluginV3Context } from './context';
+import {
+  PLUGIN_CREATE_ACTION_EVENT,
+  PLUGIN_ENGINE_READY,
+  PLUGIN_GET_APP_STYLE_URL_EVENT,
+  PLUGIN_SUBSCRIBE_TO_EVENT,
+  getActionEvent,
+} from './events';
+import { instanceTypes } from './frame-worker';
+import { PluginParentWorker } from './parent-worker';
+
+const mainInstanceOnlyEvents: (keyof PluginV3Context)[] = [
+  'createPanel',
+  'destroyPanel',
+  'createAction',
+];
+
+// methods to be excluded from the generic listener creation since they are handled specially
+const speciallyHandledMethods: (keyof PluginV3Context)[] = ['on', 'createAction'];
+
+export class PluginParentEngine {
+  private context?: PluginV3Context;
+  subscribedEvents: string[] = [];
+
+  constructor(private worker: PluginParentWorker) {}
+
+  start(context: PluginV3Context) {
+    this.context = context;
+    this.prepareListeners();
+    this.handleEvents();
+    if (this.worker.getInstanceType() === instanceTypes.MAIN) {
+      this.handleActionEvents();
+    }
+
+    // send a message to the worker to indicate that the plugin engine is ready
+    this.worker.send(PLUGIN_ENGINE_READY);
+  }
+
+  prepareListeners() {
+    if (!this.context) {
+      return;
+    }
+    // loop over all the context object method and create a listener for each
+    Object.entries(this.context).forEach(([k, fn]) => {
+      // skip the methods that are handled specially
+      if (speciallyHandledMethods.includes(k as keyof PluginV3Context)) {
+        return;
+      }
+      // skip the main frame only events if the frame is not the main frame
+      if (
+        this.worker.getInstanceType() !== instanceTypes.MAIN &&
+        mainInstanceOnlyEvents.includes(k as keyof PluginV3Context)
+      ) {
+        return;
+      }
+      this.worker.respond(k, async (...args) => {
+        return fn(...args);
+      });
+    });
+  }
+
+  handleEvents() {
+    this.worker.respond(PLUGIN_SUBSCRIBE_TO_EVENT, async (event) => {
+      if (typeof event !== 'string') {
+        return;
+      }
+
+      // we only need to subscribe to an event once here. In the frame, we manage the listeners separately
+      if (this.subscribedEvents.includes(event)) {
+        return;
+      }
+
+      if (!this.context) {
+        return;
+      }
+
+      this.context.on(event as unknown as keyof PluginEventPayloadMap, (...args) => {
+        this.worker.request(event, ...args);
+      });
+
+      // keep track of the events that have been subscribed to
+      this.subscribedEvents.push(event);
+    });
+
+    this.worker.respond(PLUGIN_GET_APP_STYLE_URL_EVENT, async () => {
+      const styleSheets = Array.from(document.styleSheets);
+      // Get the style sheet URLs
+      const styleUrls = styleSheets
+        .map((sheet) => {
+          if (sheet?.href) {
+            return sheet.href;
+          }
+          return '';
+        })
+        .filter(Boolean);
+
+      const htmlClasses = Array.from(document.documentElement.classList);
+      // Get the styles that are applicable to the current theme of the page
+      const styles = styleSheets
+        .map((sheet) => {
+          return Array.from(sheet.cssRules)
+            .map((rule) => rule.cssText)
+            .join('');
+        })
+        .filter((css) => {
+          return htmlClasses.some((htmlClass) => css.includes(`.${htmlClass}`));
+        });
+
+      return { styleUrls, styles, htmlClasses };
+    });
+  }
+
+  handleActionEvents() {
+    // handle the createAction method specially
+    this.worker.respond(PLUGIN_CREATE_ACTION_EVENT, async (opts) => {
+      if (!this.context) {
+        return;
+      }
+      let id: string | undefined = '';
+      // create action and assign the real id to the id variable
+      id = await this.context.createAction({
+        ...(opts as CreateActionOptions),
+        execute: async (...args) => {
+          if (!id) {
+            return;
+          }
+          return this.worker.request(getActionEvent(id), ...args);
+        },
+      });
+      return id;
+    });
+  }
+
+  destroy() {
+    this.worker.destroy();
+  }
+}

--- a/packages/altair-core/src/plugin/v3/parent-worker.ts
+++ b/packages/altair-core/src/plugin/v3/parent-worker.ts
@@ -1,0 +1,100 @@
+import { EvaluatorWorker, EventData } from '../../evaluator/worker';
+import { urlWithParams } from '../../utils/url';
+import { FrameQueryParams, InstanceType, instanceTypes } from './frame-worker';
+
+export interface PluginParentWorkerOptions {
+  id: string;
+  pluginEntrypointUrl: string;
+  disableAppend?: boolean;
+  instanceType?: InstanceType;
+  additionalParams?: Record<string, string>;
+  additionalSandboxAttributes?: string[];
+}
+export class PluginParentWorker extends EvaluatorWorker {
+  constructor(private opts: PluginParentWorkerOptions) {
+    super();
+  }
+
+  private iframe = this.createIframe();
+
+  private frameReadyPromise = new Promise<void>((resolve) => {
+    this.iframe.addEventListener('load', () => {
+      resolve();
+    });
+  });
+
+  private createIframe() {
+    const iframe = document.createElement('iframe');
+    iframe.id = this.opts.id;
+    if (this.opts.instanceType === instanceTypes.PANEL) {
+      iframe.style.width = '100%';
+      iframe.style.height = '100%';
+      iframe.style.border = 'none';
+    } else {
+      iframe.style.display = 'none';
+    }
+
+    const params: FrameQueryParams = {
+      ...this.opts.additionalParams,
+      sc: window.location.origin,
+      id: this.opts.id,
+      instanceType: this.getInstanceType(),
+    };
+    const url = urlWithParams(this.opts.pluginEntrypointUrl, params);
+    iframe.src = url;
+
+    iframe.sandbox.add('allow-scripts');
+    iframe.sandbox.add('allow-same-origin');
+    if (this.opts.additionalSandboxAttributes) {
+      this.opts.additionalSandboxAttributes.forEach((attr) => {
+        iframe.sandbox.add(attr);
+      });
+    }
+    iframe.referrerPolicy = 'no-referrer';
+    if (!this.opts.disableAppend) {
+      document.body.appendChild(iframe);
+    }
+    return iframe;
+  }
+
+  private async frameReady() {
+    await this.frameReadyPromise;
+  }
+
+  getIframe() {
+    return this.iframe;
+  }
+
+  getInstanceType() {
+    return this.opts.instanceType ?? instanceTypes.MAIN;
+  }
+
+  onMessage<T extends string, P = unknown>(
+    handler: (e: EventData<T, P>) => void
+  ): void {
+    window.addEventListener(
+      'message',
+      (e) => {
+        if (e.origin !== new URL(this.opts.pluginEntrypointUrl).origin) {
+          return;
+        }
+        handler(e.data);
+      },
+      false
+    );
+  }
+  send<T extends string>(type: T, payload?: unknown): void {
+    this.frameReady().then(() => {
+      this.iframe.contentWindow?.postMessage(
+        { type, payload },
+        this.opts.pluginEntrypointUrl
+      );
+    });
+  }
+  onError(handler: (err: unknown) => void): void {
+    this.iframe.addEventListener('error', handler);
+  }
+  destroy(): void {
+    this.iframe.remove();
+  }
+}

--- a/packages/altair-core/src/plugin/v3/plugin.ts
+++ b/packages/altair-core/src/plugin/v3/plugin.ts
@@ -1,0 +1,28 @@
+import { PluginV3Context } from './context';
+import { PluginFrameEngine } from './frame-engine';
+import { PluginFrameWorker } from './frame-worker';
+import { AltairV3Panel } from './panel';
+
+export interface PluginV3Options {
+  panels: Record<string, AltairV3Panel>;
+}
+
+export abstract class PluginV3 {
+  private engine: PluginFrameEngine;
+  constructor(private options: PluginV3Options = { panels: {} }) {
+    const worker = new PluginFrameWorker();
+    this.engine = new PluginFrameEngine(worker, this.options);
+    this.initializeWhenReady();
+  }
+  // TODO: Pass type of keyof panels to context for better type checking
+  private initializeWhenReady() {
+    if (!this.engine.canInitialize()) {
+      return;
+    }
+    this.engine.ready().then(() => {
+      this.initialize(this.engine.getContext());
+    });
+  }
+  abstract initialize(ctx: PluginV3Context): void;
+  abstract destroy(): void;
+}

--- a/packages/altair-core/src/plugin/v3/source.ts
+++ b/packages/altair-core/src/plugin/v3/source.ts
@@ -1,0 +1,9 @@
+/**
+ * Defines the repository of the plugin.
+ * Used to know where to get the plugin from.
+ */
+export enum PluginSource {
+  NPM = 'npm',
+  GITHUB = 'github',
+  URL = 'url',
+}

--- a/packages/altair-core/src/script/evaluator-engine.ts
+++ b/packages/altair-core/src/script/evaluator-engine.ts
@@ -1,1 +1,0 @@
-export class EvaluatorEngine {}

--- a/packages/altair-core/src/types/state/local.interfaces.ts
+++ b/packages/altair-core/src/types/state/local.interfaces.ts
@@ -1,22 +1,34 @@
 import { PluginBase } from '../../plugin/base';
 import { PluginContext } from '../../plugin/context/context.interface';
 import { AltairPanel } from '../../plugin/panel';
-import { AltairPlugin } from '../../plugin/plugin.interfaces';
+import { AltairV1Plugin } from '../../plugin/plugin.interfaces';
 import { AltairUiAction } from '../../plugin/ui-action';
+import { PluginV3Context } from '../../plugin/v3/context';
+import { PluginV3Manifest } from '../../plugin/v3/manifest';
+import { PluginParentEngine } from '../../plugin/v3/parent-engine';
 import { IDictionary } from '../shared';
 import { PerWindowState } from './per-window.interfaces';
 
-export interface PluginStateEntry {
+export interface V1PluginStateEntry {
+  manifest_version: 1 | 2;
   name: string;
   context: PluginContext;
-  plugin: AltairPlugin;
+  plugin: AltairV1Plugin;
   isActive?: boolean;
   instance?: PluginBase;
+}
+export interface V3PluginStateEntry {
+  manifest_version: 3;
+  name: string;
+  context: PluginV3Context;
+  manifest: PluginV3Manifest;
+  engine: PluginParentEngine;
+  isActive?: boolean;
 }
 
 export interface LocalState {
   closedWindows: PerWindowState[];
-  installedPlugins: IDictionary<PluginStateEntry>;
+  installedPlugins: IDictionary<V1PluginStateEntry | V3PluginStateEntry>;
   panels: AltairPanel[];
   uiActions: AltairUiAction[];
 }

--- a/packages/altair-core/src/utils/url.ts
+++ b/packages/altair-core/src/utils/url.ts
@@ -1,0 +1,5 @@
+export const urlWithParams = (url: string, params: Record<string, string>) => {
+  const urlParams = new URLSearchParams(params);
+  const u = new URL(url);
+  return new URL(`${u.origin}${u.pathname}?${urlParams.toString()}`).toString();
+};


### PR DESCRIPTION
In preparing for mv3, the current plugin system wouldn't work as it requires loading remote plugin scripts directly in the app which is fundamentally an insecure approach and one that is banned in chrome extension manifest version 3. Switching to an iframe based approach removes the need to execute remote code directly in the app.


### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->