### PR TITLE
feat: hide deprecated doc items (queries, mutations, fields...)

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer-field/doc-viewer-field.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer-field/doc-viewer-field.component.html
@@ -79,6 +79,7 @@
       [data]="gqlSchema.getType(cleanName(data.type.inspect()))"
       [gqlSchema]="gqlSchema"
       [sortByOption]="sortByOption"
+      [hideDeprecatedDocItems]="hideDeprecatedDocItems"
       (goToFieldChange)="goToField($event.name, $event.parentType)"
       (goToTypeChange)="goToType($event.name)"
       (addToEditorChange)="addToEditor($event)"

--- a/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer-field/doc-viewer-field.component.ts
+++ b/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer-field/doc-viewer-field.component.ts
@@ -26,6 +26,8 @@ export class DocViewerFieldComponent {
   @Input() gqlSchema?: GraphQLSchema;
   @Input() parentType = '';
   @Input() sortByOption: SortByOptions = 'none';
+  @Input() hideDeprecatedDocItems: boolean = false;
+
   @Output() goToFieldChange = new EventEmitter();
   @Output() goToTypeChange = new EventEmitter();
   @Output() addToEditorChange = new EventEmitter();

--- a/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer-type/doc-viewer-type.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer-type/doc-viewer-type.component.html
@@ -30,24 +30,26 @@
         {{ 'DOCS_VALUES_TEXT' | translate }}
       </div>
       @for (item of getTypeEnumValues(data); track schemaItemTrackBy($index, item)) {
-        <div class="doc-viewer-item doc-viewer-item-query">
-          <div class="doc-viewer-item-query-inner">
-            <span class="doc-viewer-item-field doc-viewer-item-value">
-              {{ item.name }}
-            </span>
-            <span class="doc-viewer-item-type">
-              {{ item.value }}
-            </span>
-            <app-doc-viewer-deprecated [item]="item"></app-doc-viewer-deprecated>
+        @if (!(hideDeprecatedDocItems && item?.isDeprecated)) {
+          <div class="doc-viewer-item doc-viewer-item-query">
+            <div class="doc-viewer-item-query-inner">
+              <span class="doc-viewer-item-field doc-viewer-item-value">
+                {{ item.name }}
+              </span>
+              <span class="doc-viewer-item-type">
+                {{ item.value }}
+              </span>
+              <app-doc-viewer-deprecated [item]="item"></app-doc-viewer-deprecated>
+            </div>
+            @if (item.description) {
+              <div
+                class="doc-viewer-item-query-description"
+                markdown
+                [data]="item.description || ''"
+              ></div>
+            }
           </div>
-          @if (item.description) {
-            <div
-              class="doc-viewer-item-query-description"
-              markdown
-              [data]="item.description || ''"
-            ></div>
-          }
-        </div>
+        }
       }
     </div>
   }
@@ -124,72 +126,74 @@
           | collectionTransform: sortFieldsTransformer : sortByOption;
         track schemaItemTrackBy($index, item)
       ) {
-        <div class="doc-viewer-item doc-viewer-item-query">
-          <div class="doc-viewer-item-query-inner">
-            <span
-              class="no-link-link"
-              (click)="goToField(item.name, data.name)"
-              track-id="gotofield_docs"
-            >
-              {{ item.name }}
-            </span>
-            @if (item?.args?.length) {
-              (
-              @for (
-                arg of item.args;
-                track schemaItemTrackBy($index, arg);
-                let last = $last
-              ) {
-                <span>
-                  <span
-                    class="doc-viewer-item-field no-link-link"
-                    (click)="goToType(arg.type.inspect())"
-                  >
-                    {{ arg.name }}
-                    @if (getDefaultValue(arg)) {
-                      <span class="doc-viewer-item-value"
-                        >= {{ getDefaultValue(arg) }}</span
-                      >
+        @if (!(hideDeprecatedDocItems && item?.isDeprecated)) {
+          <div class="doc-viewer-item doc-viewer-item-query">
+            <div class="doc-viewer-item-query-inner">
+              <span
+                class="no-link-link"
+                (click)="goToField(item.name, data.name)"
+                track-id="gotofield_docs"
+              >
+                {{ item.name }}
+              </span> 
+              @if (item?.args?.length) {
+                (
+                @for (
+                  arg of item.args;
+                  track schemaItemTrackBy($index, arg);
+                  let last = $last
+                ) {
+                  <span>
+                    <span
+                      class="doc-viewer-item-field no-link-link"
+                      (click)="goToType(arg.type.inspect())"
+                    >
+                      {{ arg.name }}
+                      @if (getDefaultValue(arg)) {
+                        <span class="doc-viewer-item-value"
+                          >= {{ getDefaultValue(arg) }}</span
+                        >
+                      }
+                    </span>
+                    <span
+                      class="doc-viewer-item-type no-link-link"
+                      (click)="goToType(arg.type.inspect())"
+                      >{{ arg.type.inspect() }}</span
+                    >
+                    @if (!last) {
+                      <span>,</span>
                     }
                   </span>
-                  <span
-                    class="doc-viewer-item-type no-link-link"
-                    (click)="goToType(arg.type.inspect())"
-                    >{{ arg.type.inspect() }}</span
-                  >
-                  @if (!last) {
-                    <span>,</span>
-                  }
-                </span>
+                }
+                )
               }
-              )
-            }
-            <span
-              class="doc-viewer-item-type doc-viewer-item-query-type no-link-link"
-              (click)="goToType(item.type.inspect())"
+              <span
+                class="doc-viewer-item-type doc-viewer-item-query-type no-link-link"
+                (click)="goToType(item.type.inspect())"
+              >
+                {{ item.type.inspect() }}
+              </span>
+            </div>
+            <app-doc-viewer-deprecated [item]="item"></app-doc-viewer-deprecated>
+            <div
+              class="doc-viewer-item-query-description"
+              markdown
+              [data]="item.description || ''"
+            ></div>
+            <button
+              class="doc-viewer-item-query-add-btn"
+              (click)="addToEditor(item.name, data.name)"
+              track-id="add_query"
             >
-              {{ item.type.inspect() }}
-            </span>
+              @if (isRootType(data.name)) {
+                {{ 'DOCS_ADD_QUERY_TEXT' | translate }}
+              }
+              @if (!isRootType(data.name)) {
+                {{ 'DOCS_ADD_FRAGMENT_TEXT' | translate }}
+              }
+            </button>
           </div>
-          <app-doc-viewer-deprecated [item]="item"></app-doc-viewer-deprecated>
-          <div
-            class="doc-viewer-item-query-description"
-            markdown
-            [data]="item.description || ''"
-          ></div>
-          <button
-            class="doc-viewer-item-query-add-btn"
-            (click)="addToEditor(item.name, data.name)"
-            track-id="add_query"
-          >
-            @if (isRootType(data.name)) {
-              {{ 'DOCS_ADD_QUERY_TEXT' | translate }}
-            }
-            @if (!isRootType(data.name)) {
-              {{ 'DOCS_ADD_FRAGMENT_TEXT' | translate }}
-            }
-          </button>
-        </div>
+        }
       }
     </div>
   }

--- a/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer-type/doc-viewer-type.component.ts
+++ b/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer-type/doc-viewer-type.component.ts
@@ -33,6 +33,8 @@ export class DocViewerTypeComponent {
   @Input() data?: GraphQLNamedType | null;
   @Input() gqlSchema?: GraphQLSchema;
   @Input() sortByOption: SortByOptions = 'none';
+  @Input() hideDeprecatedDocItems: boolean = false;
+  
   @Output() goToFieldChange = new EventEmitter();
   @Output() goToTypeChange = new EventEmitter();
   @Output() addToEditorChange = new EventEmitter();

--- a/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer/doc-viewer.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer/doc-viewer.component.html
@@ -115,6 +115,7 @@
                   [data]="gqlSchema.getType(docView.name)"
                   [gqlSchema]="gqlSchema"
                   [sortByOption]="sortFieldsByOption"
+                  [hideDeprecatedDocItems]="hideDeprecatedDocItems"
                   (goToFieldChange)="goToField($event.name, $event.parentType)"
                   (goToTypeChange)="goToType($event.name)"
                   (addToEditorChange)="addToEditor($event.name, $event.parentType)"
@@ -123,12 +124,13 @@
               }
             }
             @case ('field') {
-              @if (docView.view === 'field') {
+              @if (!(hideDeprecatedDocItems && getField(docView)?.isDeprecated) && docView.view === 'field') {
                 <app-doc-viewer-field
                   [data]="getField(docView)"
                   [gqlSchema]="gqlSchema"
                   [parentType]="docView.parentType"
                   [sortByOption]="sortFieldsByOption"
+                  [hideDeprecatedDocItems]="hideDeprecatedDocItems"
                   (goToFieldChange)="goToField($event.name, $event.parentType)"
                   (goToTypeChange)="goToType($event.name)"
                   (addToEditorChange)="addToEditor($event.name, $event.parentType)"

--- a/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer/doc-viewer.component.ts
+++ b/packages/altair-app/src/app/modules/altair/components/doc-viewer/doc-viewer/doc-viewer.component.ts
@@ -33,6 +33,7 @@ import { debounce } from 'lodash-es';
 export class DocViewerComponent implements OnChanges {
   @Input() gqlSchema?: GraphQLSchema;
   @Input() allowIntrospection = true;
+  @Input() hideDeprecatedDocItems = false;
   @Input() isLoading = false;
   @Input() addQueryDepthLimit = this.altairConfig.add_query_depth_limit;
   @Input() tabSize = this.altairConfig.tab_size;

--- a/packages/altair-app/src/app/modules/altair/containers/window/window.component.html
+++ b/packages/altair-app/src/app/modules/altair/containers/window/window.component.html
@@ -88,6 +88,7 @@
         [ngClass]="{ 'hide-doc': (showDocs$ | async) !== true }"
         [isLoading]="docsIsLoading$ | async"
         [addQueryDepthLimit]="addQueryDepthLimit$ | async"
+        [hideDeprecatedDocItems]="hideDeprecatedDocItems$ | async"
         [tabSize]="tabSize$ | async"
         [lastUpdatedAt]="schemaLastUpdatedAt$ | async"
         (setDocViewChange)="setDocView($event)"

--- a/packages/altair-app/src/app/modules/altair/containers/window/window.component.ts
+++ b/packages/altair-app/src/app/modules/altair/containers/window/window.component.ts
@@ -177,7 +177,7 @@ export class WindowComponent implements OnInit {
       select((state) => state.settings.disableLineNumbers)
     );
     this.hideDeprecatedDocItems$ = this.store.pipe(
-      select((state) => state.settings.hideDeprecatedDocItems)
+      select((state) => state.settings['doc.hideDeprecatedItems'])
     );
     this.collections$ = this.store.pipe(select((state) => state.collection.list));
     this.activeWindowId$ = this.store.pipe(

--- a/packages/altair-app/src/app/modules/altair/containers/window/window.component.ts
+++ b/packages/altair-app/src/app/modules/altair/containers/window/window.component.ts
@@ -107,6 +107,7 @@ export class WindowComponent implements OnInit {
   addQueryDepthLimit$: Observable<number>;
   tabSize$: Observable<number>;
   disableLineNumbers$: Observable<boolean | undefined>;
+  hideDeprecatedDocItems$: Observable<boolean | undefined>;
   enableExperimental$: Observable<boolean | undefined>;
   betaDisableNewEditor$: Observable<boolean | undefined>;
   autoscrollResponseList$: Observable<boolean>;
@@ -174,6 +175,9 @@ export class WindowComponent implements OnInit {
     );
     this.disableLineNumbers$ = this.store.pipe(
       select((state) => state.settings.disableLineNumbers)
+    );
+    this.hideDeprecatedDocItems$ = this.store.pipe(
+      select((state) => state.settings.hideDeprecatedDocItems)
     );
     this.collections$ = this.store.pipe(select((state) => state.collection.list));
     this.activeWindowId$ = this.store.pipe(

--- a/packages/altair-core/src/types/state/settings.interfaces.ts
+++ b/packages/altair-core/src/types/state/settings.interfaces.ts
@@ -107,6 +107,11 @@ export interface SettingsState {
   disableLineNumbers?: boolean;
 
   /**
+   * Hides deprecated Doc items
+   */
+  hideDeprecatedDocItems?: boolean;
+
+  /**
    * Specify custom theme config to override the specified theme values
    */
   themeConfig?: ICustomTheme;

--- a/packages/altair-core/src/types/state/settings.interfaces.ts
+++ b/packages/altair-core/src/types/state/settings.interfaces.ts
@@ -109,7 +109,7 @@ export interface SettingsState {
   /**
    * Hides deprecated Doc items
    */
-  hideDeprecatedDocItems?: boolean;
+  'doc.hideDeprecatedItems'?: boolean;
 
   /**
    * Specify custom theme config to override the specified theme values


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
[#2220 ](https://github.com/altair-graphql/altair/issues/2220)
### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

Adds a toggle button in settings to hide deprecated doc items
![Screenshot from 2024-06-21 00-19-10](https://github.com/altair-graphql/altair/assets/77873211/4cb157ad-4b19-4d47-a536-b834cec61825)

When the toggle button is disabled, the deprecated items should be visible
![Screenshot from 2024-06-21 00-20-19](https://github.com/altair-graphql/altair/assets/77873211/cdc83c21-2a76-49f4-96cc-1ce4a615a587)

When the toggle button is enabled, the deprecated item should be hidden.
![Screenshot from 2024-06-21 00-20-53](https://github.com/altair-graphql/altair/assets/77873211/9b3bafc7-fca8-49f6-8280-19bf35dd3761)

