### PR TITLE
[altair-fastify-plugin] Add nodenext compatible typings and exports

### DIFF
--- a/packages/altair-fastify-plugin/index.d.ts
+++ b/packages/altair-fastify-plugin/index.d.ts
@@ -1,0 +1,16 @@
+import type { FastifyPluginCallback } from 'fastify';
+import type { AltairFastifyPluginOptions as PluginOptions } from './dist/index';
+
+type FastifyAltair = FastifyPluginCallback<PluginOptions>;
+
+namespace fastifyAltairPlugin {
+  export type AltairFastifyPluginOptions = PluginOptions;
+  export const fastifyAltairPlugin: FastifyAltair;
+  export { fastifyAltairPlugin as default };
+}
+
+declare function fastifyAltairPlugin(
+  ...params: Parameters<FastifyAltair>
+): ReturnType<FastifyAltair>;
+
+export = fastifyAltairPlugin;

--- a/packages/altair-fastify-plugin/index.js
+++ b/packages/altair-fastify-plugin/index.js
@@ -1,0 +1,5 @@
+const fastifyAltairPlugin = require('./dist/index.js').default;
+
+module.exports = fastifyAltairPlugin;
+module.exports.default = fastifyAltairPlugin;
+module.exports.fastifyAltairPlugin = fastifyAltairPlugin;

--- a/packages/altair-fastify-plugin/package.json
+++ b/packages/altair-fastify-plugin/package.json
@@ -28,7 +28,7 @@
     "graphql"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "index.js",
   "peerDependencies": {
     "fastify": "^4.0.3"
   },
@@ -38,5 +38,5 @@
     "prepare": "tsc",
     "test": "echo \"Error: no test specified\" && exit 0"
   },
-  "types": "dist/index.d.ts"
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
### Fixes #2666

### Checks

- [X] Ran `yarn test-build`
- [X] Updated relevant documentations
- [X] Updated matching config options in altair-static

### Changes proposed in this pull request:

This introduces a new index.js set of exports that are compatible with both CJS and ESM modules using the Fastify "infamous triplet" refactor for making exports support all the various import types. (https://github.com/fastify/fastify/issues/4349)

I tried to do it with pure Typescript but I could not find a way to have Typescript compile into the necessary format so I created a separate set of index.js/index.d.ts which works when tested in both ESM and CJS environments.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add nodenext compatible typings and exports to the altair-fastify-plugin to support both CommonJS and ESM modules, using a separate set of index.js and index.d.ts files.

New Features:
- Introduce nodenext compatible typings and exports for the altair-fastify-plugin, supporting both CommonJS and ESM modules.

<!-- Generated by sourcery-ai[bot]: end summary -->