### PR TITLE
only use local sandbox if same origin

### DIFF
--- a/packages/altair-core/src/config/index.ts
+++ b/packages/altair-core/src/config/index.ts
@@ -13,6 +13,13 @@ import { UrlConfig, urlMap } from './urls';
 
 const isTranslateMode = (window as TODO).__ALTAIR_TRANSLATE__;
 
+const parseUrl = (url: string) => {
+  try {
+    return new URL(url);
+  } catch (e) {
+    return;
+  }
+};
 export class AltairConfig {
   private localSandboxUrl: string | undefined;
   private useLocalSandboxUrl = false;
@@ -135,7 +142,10 @@ export class AltairConfig {
 
   private getPossibleLocalSandBoxUrl() {
     // check document base url
-    if (document.baseURI) {
+    if (
+      document.baseURI &&
+      parseUrl(document.baseURI)?.origin === window.location.origin
+    ) {
       // add iframe-sandbox path to base url
       if (document.baseURI.endsWith('/')) {
         return new URL(document.baseURI + 'iframe-sandbox/index.html');


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Bug Fixes:
- Ensure local sandbox is used only if the document's base URI has the same origin as the window location.