### PR TITLE
implemented OAuth client credentials flow

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/authorization/authorization-oauth2/authorization-oauth2.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/authorization/authorization-oauth2/authorization-oauth2.component.html
@@ -19,7 +19,7 @@
     </nz-form-control>
   </nz-form-item>
 
-  @if (form.value.type !== oauth2Type.CLIENT_CREDENTIALS) {
+  @if (isEnabledField('clientId')) {
     <nz-form-item>
       <nz-form-label nzRequired nzFor="clientId">Client ID</nz-form-label>
       <nz-form-control
@@ -36,6 +36,8 @@
         />
       </nz-form-control>
     </nz-form-item>
+  }
+  @if (isEnabledField('clientSecret')) {
     <nz-form-item>
       <nz-form-label nzRequired nzFor="clientSecret">Client Secret</nz-form-label>
       <nz-form-control
@@ -52,6 +54,8 @@
         />
       </nz-form-control>
     </nz-form-item>
+  }
+  @if (isEnabledField('redirectUri')) {
     <nz-form-item>
       <nz-form-label
         nzRequired
@@ -74,6 +78,8 @@
         />
       </nz-form-control>
     </nz-form-item>
+  }
+  @if (isEnabledField('authorizationEndpoint')) {
     <nz-form-item>
       <nz-form-label nzRequired nzFor="authorizationEndpoint"
         >Authorization URL</nz-form-label
@@ -92,6 +98,8 @@
         />
       </nz-form-control>
     </nz-form-item>
+  }
+  @if (isEnabledField('tokenEndpoint')) {
     <nz-form-item>
       <nz-form-label nzRequired nzFor="tokenEndpoint"
         >Access token URL</nz-form-label
@@ -110,10 +118,12 @@
         />
       </nz-form-control>
     </nz-form-item>
+  }
+  @if (isEnabledField('scopes')) {
     <nz-form-item>
       <nz-form-label
         nzRequired
-        nzFor="scope"
+        nzFor="scopes"
         nzTooltipTitle="The scope of the request. It can contain multiple space-delimited values"
       >
         Scope
@@ -125,14 +135,16 @@
       >
         <app-x-input
           nz-input
-          formControlName="scope"
-          id="scope"
+          formControlName="scopes"
+          id="scopes"
           class="input"
           placeholder="read:users user:email"
           autocomplete="off"
         />
       </nz-form-control>
     </nz-form-item>
+  }
+  @if (isEnabledField('state')) {
     <nz-form-item>
       <nz-form-label nzFor="state">State</nz-form-label>
       <nz-form-control
@@ -149,94 +161,20 @@
         />
       </nz-form-control>
     </nz-form-item>
-    @if (form.value.type === oauth2Type.AUTHORIZATION_CODE_PKCE) {
-      <nz-form-item>
-        <nz-form-label nzFor="codeVerifier">Code verifier</nz-form-label>
-        <nz-form-control
-          [nzSm]="14"
-          [nzXs]="24"
-          nzErrorTip="The input is not a valid code verifier!"
-        >
-          <app-x-input
-            nz-input
-            formControlName="codeVerifier"
-            id="codeVerifier"
-            class="input"
-            autocomplete="off"
-          />
-        </nz-form-control>
-      </nz-form-item>
-    }
-  } @else {
+  }
+  @if (isEnabledField('codeVerifier')) {
     <nz-form-item>
-      <nz-form-label nzRequired nzFor="clientId">Client ID</nz-form-label>
+      <nz-form-label nzFor="codeVerifier">Code verifier</nz-form-label>
       <nz-form-control
         [nzSm]="14"
         [nzXs]="24"
-        nzErrorTip="The input is not a valid client ID!"
+        nzErrorTip="The input is not a valid code verifier!"
       >
         <app-x-input
           nz-input
-          formControlName="clientId"
-          id="clientId"
+          formControlName="codeVerifier"
+          id="codeVerifier"
           class="input"
-          autocomplete="off"
-        />
-      </nz-form-control>
-    </nz-form-item>
-    <nz-form-item>
-      <nz-form-label nzRequired nzFor="clientSecret">Client Secret</nz-form-label>
-      <nz-form-control
-        [nzSm]="14"
-        [nzXs]="24"
-        nzErrorTip="The input is not a valid client secret!"
-      >
-        <app-x-input
-          nz-input
-          formControlName="clientSecret"
-          id="clientSecret"
-          class="input"
-          autocomplete="off"
-        />
-      </nz-form-control>
-    </nz-form-item>
-    <nz-form-item>
-      <nz-form-label nzRequired nzFor="tokenEndpoint"
-        >Access token URL</nz-form-label
-      >
-      <nz-form-control
-        [nzSm]="14"
-        [nzXs]="24"
-        nzErrorTip="The input is not a valid URL!"
-      >
-        <app-x-input
-          nz-input
-          formControlName="tokenEndpoint"
-          id="tokenEndpoint"
-          class="input"
-          autocomplete="off"
-        />
-      </nz-form-control>
-    </nz-form-item>
-    <nz-form-item>
-      <nz-form-label
-        nzRequired
-        nzFor="scope"
-        nzTooltipTitle="The scope of the request. It can contain multiple space-delimited values"
-      >
-        Scope
-      </nz-form-label>
-      <nz-form-control
-        [nzSm]="14"
-        [nzXs]="24"
-        nzErrorTip="The input is not a valid scope!"
-      >
-        <app-x-input
-          nz-input
-          formControlName="scope"
-          id="scope"
-          class="input"
-          placeholder="read:users user:email"
           autocomplete="off"
         />
       </nz-form-control>

--- a/packages/altair-app/src/app/modules/altair/components/authorization/authorization-oauth2/authorization-oauth2.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/authorization/authorization-oauth2/authorization-oauth2.component.html
@@ -11,154 +11,277 @@
           [nzValue]="oauth2Type.AUTHORIZATION_CODE_PKCE"
           nzLabel="Authorization Code with PKCE"
         ></nz-option>
+        <nz-option
+          [nzValue]="oauth2Type.CLIENT_CREDENTIALS"
+          nzLabel="Client Credentials"
+        ></nz-option>
       </nz-select>
     </nz-form-control>
   </nz-form-item>
-  <nz-form-item>
-    <nz-form-label nzRequired nzFor="clientId">Client ID</nz-form-label>
-    <nz-form-control
-      [nzSm]="14"
-      [nzXs]="24"
-      nzErrorTip="The input is not a valid client ID!"
-    >
-      <app-x-input
-        nz-input
-        formControlName="clientId"
-        id="clientId"
-        class="input"
-        autocomplete="off"
-      />
-    </nz-form-control>
-  </nz-form-item>
-  <nz-form-item>
-    <nz-form-label nzRequired nzFor="clientSecret">Client Secret</nz-form-label>
-    <nz-form-control
-      [nzSm]="14"
-      [nzXs]="24"
-      nzErrorTip="The input is not a valid client secret!"
-    >
-      <app-x-input
-        nz-input
-        formControlName="clientSecret"
-        id="clientSecret"
-        class="input"
-        autocomplete="off"
-      />
-    </nz-form-control>
-  </nz-form-item>
-  <nz-form-item>
-    <nz-form-label
-      nzRequired
-      nzFor="redirectUri"
-      nzTooltipTitle="The callback (redirect) URL"
-      >Callback URL (readonly)</nz-form-label
-    >
-    <nz-form-control
-      [nzSm]="14"
-      [nzXs]="24"
-      nzErrorTip="The input is not a valid URL!"
-    >
-      <app-x-input
-        nz-input
-        formControlName="redirectUri"
-        id="redirectUri"
-        class="input input--transparent"
-        autocomplete="off"
-        [readonly]="true"
-      />
-    </nz-form-control>
-  </nz-form-item>
-  <nz-form-item>
-    <nz-form-label nzRequired nzFor="authorizationEndpoint"
-      >Authorization URL</nz-form-label
-    >
-    <nz-form-control
-      [nzSm]="14"
-      [nzXs]="24"
-      nzErrorTip="The input is not a valid URL!"
-    >
-      <app-x-input
-        nz-input
-        formControlName="authorizationEndpoint"
-        id="authorizationEndpoint"
-        class="input"
-        autocomplete="off"
-      />
-    </nz-form-control>
-  </nz-form-item>
-  <nz-form-item>
-    <nz-form-label nzRequired nzFor="tokenEndpoint">Access token URL</nz-form-label>
-    <nz-form-control
-      [nzSm]="14"
-      [nzXs]="24"
-      nzErrorTip="The input is not a valid URL!"
-    >
-      <app-x-input
-        nz-input
-        formControlName="tokenEndpoint"
-        id="tokenEndpoint"
-        class="input"
-        autocomplete="off"
-      />
-    </nz-form-control>
-  </nz-form-item>
-  <nz-form-item>
-    <nz-form-label
-      nzRequired
-      nzFor="scope"
-      nzTooltipTitle="The scope of the request. It can contain multiple space-delimited values"
-    >
-      Scope
-    </nz-form-label>
-    <nz-form-control
-      [nzSm]="14"
-      [nzXs]="24"
-      nzErrorTip="The input is not a valid scope!"
-    >
-      <app-x-input
-        nz-input
-        formControlName="scope"
-        id="scope"
-        class="input"
-        placeholder="read:users user:email"
-        autocomplete="off"
-      />
-    </nz-form-control>
-  </nz-form-item>
-  <nz-form-item>
-    <nz-form-label nzFor="state">State</nz-form-label>
-    <nz-form-control
-      [nzSm]="14"
-      [nzXs]="24"
-      nzErrorTip="The input is not a valid state!"
-    >
-      <app-x-input
-        nz-input
-        formControlName="state"
-        id="state"
-        class="input"
-        autocomplete="off"
-      />
-    </nz-form-control>
-  </nz-form-item>
-  @if (form.value.type === oauth2Type.AUTHORIZATION_CODE_PKCE) {
+
+  @if (form.value.type !== oauth2Type.CLIENT_CREDENTIALS) {
     <nz-form-item>
-      <nz-form-label nzFor="codeVerifier">Code verifier</nz-form-label>
+      <nz-form-label nzRequired nzFor="clientId">Client ID</nz-form-label>
       <nz-form-control
         [nzSm]="14"
         [nzXs]="24"
-        nzErrorTip="The input is not a valid code verifier!"
+        nzErrorTip="The input is not a valid client ID!"
       >
         <app-x-input
           nz-input
-          formControlName="codeVerifier"
-          id="codeVerifier"
+          formControlName="clientId"
+          id="clientId"
           class="input"
           autocomplete="off"
         />
       </nz-form-control>
     </nz-form-item>
+    <nz-form-item>
+      <nz-form-label nzRequired nzFor="clientSecret">Client Secret</nz-form-label>
+      <nz-form-control
+        [nzSm]="14"
+        [nzXs]="24"
+        nzErrorTip="The input is not a valid client secret!"
+      >
+        <app-x-input
+          nz-input
+          formControlName="clientSecret"
+          id="clientSecret"
+          class="input"
+          autocomplete="off"
+        />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label
+        nzRequired
+        nzFor="redirectUri"
+        nzTooltipTitle="The callback (redirect) URL"
+        >Callback URL (readonly)</nz-form-label
+      >
+      <nz-form-control
+        [nzSm]="14"
+        [nzXs]="24"
+        nzErrorTip="The input is not a valid URL!"
+      >
+        <app-x-input
+          nz-input
+          formControlName="redirectUri"
+          id="redirectUri"
+          class="input input--transparent"
+          autocomplete="off"
+          [readonly]="true"
+        />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label nzRequired nzFor="authorizationEndpoint"
+        >Authorization URL</nz-form-label
+      >
+      <nz-form-control
+        [nzSm]="14"
+        [nzXs]="24"
+        nzErrorTip="The input is not a valid URL!"
+      >
+        <app-x-input
+          nz-input
+          formControlName="authorizationEndpoint"
+          id="authorizationEndpoint"
+          class="input"
+          autocomplete="off"
+        />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label nzRequired nzFor="tokenEndpoint"
+        >Access token URL</nz-form-label
+      >
+      <nz-form-control
+        [nzSm]="14"
+        [nzXs]="24"
+        nzErrorTip="The input is not a valid URL!"
+      >
+        <app-x-input
+          nz-input
+          formControlName="tokenEndpoint"
+          id="tokenEndpoint"
+          class="input"
+          autocomplete="off"
+        />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label
+        nzRequired
+        nzFor="scope"
+        nzTooltipTitle="The scope of the request. It can contain multiple space-delimited values"
+      >
+        Scope
+      </nz-form-label>
+      <nz-form-control
+        [nzSm]="14"
+        [nzXs]="24"
+        nzErrorTip="The input is not a valid scope!"
+      >
+        <app-x-input
+          nz-input
+          formControlName="scope"
+          id="scope"
+          class="input"
+          placeholder="read:users user:email"
+          autocomplete="off"
+        />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label nzFor="state">State</nz-form-label>
+      <nz-form-control
+        [nzSm]="14"
+        [nzXs]="24"
+        nzErrorTip="The input is not a valid state!"
+      >
+        <app-x-input
+          nz-input
+          formControlName="state"
+          id="state"
+          class="input"
+          autocomplete="off"
+        />
+      </nz-form-control>
+    </nz-form-item>
+    @if (form.value.type === oauth2Type.AUTHORIZATION_CODE_PKCE) {
+      <nz-form-item>
+        <nz-form-label nzFor="codeVerifier">Code verifier</nz-form-label>
+        <nz-form-control
+          [nzSm]="14"
+          [nzXs]="24"
+          nzErrorTip="The input is not a valid code verifier!"
+        >
+          <app-x-input
+            nz-input
+            formControlName="codeVerifier"
+            id="codeVerifier"
+            class="input"
+            autocomplete="off"
+          />
+        </nz-form-control>
+      </nz-form-item>
+    }
+  } @else {
+    <nz-form-item>
+      <nz-form-label nzRequired nzFor="clientId">Client ID</nz-form-label>
+      <nz-form-control
+        [nzSm]="14"
+        [nzXs]="24"
+        nzErrorTip="The input is not a valid client ID!"
+      >
+        <app-x-input
+          nz-input
+          formControlName="clientId"
+          id="clientId"
+          class="input"
+          autocomplete="off"
+        />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label nzRequired nzFor="clientSecret">Client Secret</nz-form-label>
+      <nz-form-control
+        [nzSm]="14"
+        [nzXs]="24"
+        nzErrorTip="The input is not a valid client secret!"
+      >
+        <app-x-input
+          nz-input
+          formControlName="clientSecret"
+          id="clientSecret"
+          class="input"
+          autocomplete="off"
+        />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label nzRequired nzFor="tokenEndpoint"
+        >Access token URL</nz-form-label
+      >
+      <nz-form-control
+        [nzSm]="14"
+        [nzXs]="24"
+        nzErrorTip="The input is not a valid URL!"
+      >
+        <app-x-input
+          nz-input
+          formControlName="tokenEndpoint"
+          id="tokenEndpoint"
+          class="input"
+          autocomplete="off"
+        />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label
+        nzRequired
+        nzFor="scope"
+        nzTooltipTitle="The scope of the request. It can contain multiple space-delimited values"
+      >
+        Scope
+      </nz-form-label>
+      <nz-form-control
+        [nzSm]="14"
+        [nzXs]="24"
+        nzErrorTip="The input is not a valid scope!"
+      >
+        <app-x-input
+          nz-input
+          formControlName="scope"
+          id="scope"
+          class="input"
+          placeholder="read:users user:email"
+          autocomplete="off"
+        />
+      </nz-form-control>
+    </nz-form-item>
   }
+
+  <nz-collapse nzGhost class="mb-20">
+    <nz-collapse-panel [nzHeader]="'Advanced options'" [nzActive]="false">
+      <nz-form-item>
+        <nz-form-label>Authentication format</nz-form-label>
+        <nz-form-control
+          [nzSm]="14"
+          [nzXs]="24"
+          nzErrorTip="The input is not a valid format!"
+        >
+          <nz-select formControlName="authFormat">
+            <nz-option
+              [nzValue]="authFormat.IN_BODY"
+              nzLabel="In body (default)"
+            ></nz-option>
+            <nz-option
+              [nzValue]="authFormat.BASIC_AUTH"
+              nzLabel="Basic Auth"
+            ></nz-option>
+          </nz-select>
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
+        <nz-form-label>Request format</nz-form-label>
+        <nz-form-control
+          [nzSm]="14"
+          [nzXs]="24"
+          nzErrorTip="The input is not a valid format!"
+        >
+          <nz-select formControlName="requestFormat">
+            <nz-option
+              [nzValue]="requestFormat.FORM"
+              nzLabel="Form encoded (default)"
+            ></nz-option>
+            <nz-option [nzValue]="requestFormat.JSON" nzLabel="JSON"></nz-option>
+          </nz-select>
+        </nz-form-control>
+      </nz-form-item>
+    </nz-collapse-panel>
+  </nz-collapse>
   <button class="btn btn--bordered" type="submit" (click)="handleGetAccessToken()">
     Get access token
   </button>

--- a/packages/altair-app/src/app/modules/altair/components/authorization/authorization-oauth2/authorization-oauth2.component.ts
+++ b/packages/altair-app/src/app/modules/altair/components/authorization/authorization-oauth2/authorization-oauth2.component.ts
@@ -5,11 +5,11 @@ import {
   AccessTokenErrorResponse,
   AccessTokenResponse,
   AuthFormat,
-  AuthorizationCodePKCE_OAuth2ClientOptions,
-  AuthorizationCode_OAuth2ClientOptions,
+  AuthorizationCodePKCE_OAuth2ClientOptions as AuthCodePKCEOAuth2ClientOpts,
+  AuthorizationCode_OAuth2ClientOptions as AuthCodeOAuth2ClientOpts,
   AuthorizationRedirectErrorResponse,
   AuthorizationRedirectResponse,
-  ClientCredentials_OAuth2ClientOptions,
+  ClientCredentials_OAuth2ClientOptions as ClientCredentialsOAuth2ClientOpts,
   EVENT_TYPES,
   OAuth2Client,
   OAuth2ClientOptions,
@@ -187,10 +187,7 @@ export class AuthorizationOauth2Component implements OnInit {
   }
 
   getOptionsShape() {
-    const authCodeOptionsShape: Record<
-      keyof AuthorizationCode_OAuth2ClientOptions,
-      boolean
-    > = {
+    const authCodeOptionsShape: Record<keyof AuthCodeOAuth2ClientOpts, boolean> = {
       clientId: true,
       clientSecret: true,
       redirectUri: true,
@@ -204,7 +201,7 @@ export class AuthorizationOauth2Component implements OnInit {
     };
 
     const authCodePkceOptionsShape: Record<
-      keyof AuthorizationCodePKCE_OAuth2ClientOptions,
+      keyof AuthCodePKCEOAuth2ClientOpts,
       boolean
     > = {
       ...authCodeOptionsShape,
@@ -212,7 +209,7 @@ export class AuthorizationOauth2Component implements OnInit {
     };
 
     const clientCredentialsOptionsShape: Record<
-      keyof ClientCredentials_OAuth2ClientOptions,
+      keyof ClientCredentialsOAuth2ClientOpts,
       boolean
     > = {
       clientId: true,

--- a/packages/altair-app/src/scss/_globals.scss
+++ b/packages/altair-app/src/scss/_globals.scss
@@ -149,6 +149,18 @@ h6 {
   padding: 10px;
 }
 
+.mb-5 {
+  margin-bottom: 5px;
+}
+
+.mb-10 {
+  margin-bottom: 10px;
+}
+
+.mb-20 {
+  margin-bottom: 20px;
+}
+
 @keyframes anim-rotate {
   0% {
     transform: rotate(0deg) translateZ(0);

--- a/packages/altair-core/jest.setup.js
+++ b/packages/altair-core/jest.setup.js
@@ -13,6 +13,7 @@ const { ReadableStream, TransformStream } = require('node:stream/web');
 const crypto = require('node:crypto');
 const { clearImmediate } = require('node:timers');
 const { performance } = require('node:perf_hooks');
+const { LocationMock } = require('@jedmao/location');
 
 Object.defineProperties(globalThis, {
   crypto: {
@@ -44,7 +45,16 @@ Object.defineProperties(globalThis, {
   FormData: { value: FormData },
   Request: { value: Request },
   Response: { value: Response },
+
+  // Mock the location object
+  location: {
+    value: new LocationMock('http://test.com'),
+  },
 });
+
+global.structuredClone = (data) => {
+  return JSON.parse(JSON.stringify(data));
+};
 
 global.console = {
   ...console,

--- a/packages/altair-core/package.json
+++ b/packages/altair-core/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@angular/common": "17.0.8",
+    "@jedmao/location": "^3.0.0",
     "@jest/globals": "^29.7.0",
     "@types/actioncable": "^5.2.5",
     "@types/color-name": "^1.1.4",

--- a/packages/altair-core/src/oauth2/client.spec.ts
+++ b/packages/altair-core/src/oauth2/client.spec.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
 import { OAuth2Client } from './client';
-import { OAuth2Type } from './types';
+import { AuthFormat, OAuth2Type, RequestFormat } from './types';
+import { setupServer } from 'msw/node';
+import { MswMockRequestHandler } from '../test-helpers';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
 
 describe('oauth2 client', () => {
   describe('getAuthorizationUrl', () => {
@@ -15,6 +23,8 @@ describe('oauth2 client', () => {
         scopes: ['scope1', 'scope2'],
         codeVerifier: 'codeVerifier',
         state: 'random-state',
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.JSON,
       });
 
       const url = await client.getAuthorizationUrl();
@@ -22,5 +32,562 @@ describe('oauth2 client', () => {
         'https://auth-server.com/oauth/authorize?response_type=code&client_id=clientId&redirect_uri=redirectUri&state=random-state&scope=scope1+scope2&code_challenge=N1E4yRMD7xixn_oFyO_W3htYN3rY7-HMDKJe6z6r928&code_challenge_method=S256'
       );
     });
+
+    it('should throw an error if the flow is client credentials', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.CLIENT_CREDENTIALS,
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        scopes: ['scope1', 'scope2'],
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      await expect(client.getAuthorizationUrl()).rejects.toThrow(
+        'Client Credentials flow not supported for authorization code'
+      );
+    });
   });
+  describe('getAuthorizationRedirectResponse', () => {
+    it('should return the authorization redirect response', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.AUTHORIZATION_CODE_PKCE,
+        authorizationEndpoint: 'https://auth-server.com/oauth/authorize',
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        redirectUri: 'redirectUri',
+        scopes: ['scope1', 'scope2'],
+        codeVerifier: 'codeVerifier',
+        state: 'random-state',
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      location.href =
+        'https://auth-server.com/oauth/authorize?code=code&state=random-state';
+      const response = await client.getAuthorizationRedirectResponse();
+
+      expect(response).toEqual({
+        code: 'code',
+        state: 'random-state',
+      });
+    });
+
+    it('should return the authorization redirect error response', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.AUTHORIZATION_CODE_PKCE,
+        authorizationEndpoint: 'https://auth-server.com/oauth/authorize',
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        redirectUri: 'redirectUri',
+        scopes: ['scope1', 'scope2'],
+        codeVerifier: 'codeVerifier',
+        state: 'random-state',
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      location.href =
+        'https://auth-server.com/oauth/authorize?error=access_denied&state=random-state&error_description=access+is+denied&error_uri=https%3A%2F%2Fauth-server.com%2Ferror';
+      const response = await client.getAuthorizationRedirectResponse();
+
+      expect(response).toEqual({
+        error: 'access_denied',
+        state: 'random-state',
+        error_description: 'access is denied',
+        error_uri: 'https://auth-server.com/error',
+      });
+    });
+
+    it('should return error if the state does not match', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.AUTHORIZATION_CODE_PKCE,
+        authorizationEndpoint: 'https://auth-server.com/oauth/authorize',
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        redirectUri: 'redirectUri',
+        scopes: ['scope1', 'scope2'],
+        codeVerifier: 'codeVerifier',
+        state: 'random-state',
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      location.href =
+        'https://auth-server.com/oauth/authorize?code=code&state=random-state-2';
+      const response = await client.getAuthorizationRedirectResponse();
+
+      expect(response).toEqual({
+        error: 'invalid_state',
+        error_description: 'The state is invalid',
+        state: 'random-state-2',
+      });
+    });
+
+    it('should return undefined if the state is missing', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.AUTHORIZATION_CODE_PKCE,
+        authorizationEndpoint: 'https://auth-server.com/oauth/authorize',
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        redirectUri: 'redirectUri',
+        scopes: ['scope1', 'scope2'],
+        codeVerifier: 'codeVerifier',
+        state: 'random-state',
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      location.href = 'https://auth-server.com/oauth/authorize?code=code';
+      const response = await client.getAuthorizationRedirectResponse();
+
+      expect(response).toBeUndefined();
+    });
+    it('should throw an error if the flow is client credentials', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.CLIENT_CREDENTIALS,
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        scopes: ['scope1', 'scope2'],
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      location.href =
+        'https://auth-server.com/oauth/authorize?code=code&state=random-state';
+      await expect(client.getAuthorizationRedirectResponse()).rejects.toThrow(
+        'Client Credentials flow not supported for authorization code'
+      );
+    });
+  });
+
+  describe('getAccessTokenFromCode', () => {
+    it('should return the access token from code (authFormat: in body, requestFormat: JSON)', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.AUTHORIZATION_CODE_PKCE,
+        authorizationEndpoint: 'https://auth-server.com/oauth/authorize',
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        redirectUri: 'redirectUri',
+        scopes: ['scope1', 'scope2'],
+        codeVerifier: 'codeVerifier',
+        state: 'random-state',
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      const mockHandler = new MswMockRequestHandler(
+        'https://auth-server.com/oauth/token',
+        async () => {
+          return Response.json({
+            access_token: 'access-token',
+            refresh_token: 'refresh-token',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          });
+        }
+      );
+
+      server.use(mockHandler);
+
+      const response = await client.getAccessTokenFromCode('code');
+
+      const receivedRequest = mockHandler.receivedRequest();
+      expect(receivedRequest?.method).toBe('POST');
+      expect(Object.fromEntries(receivedRequest?.headers as any)).toEqual({
+        accept: 'application/json',
+        'content-type': 'application/json',
+      });
+      expect(await receivedRequest?.json()).toEqual({
+        grant_type: 'authorization_code',
+        code: 'code',
+        redirect_uri: 'redirectUri',
+        client_id: 'clientId',
+        client_secret: 'clientSecret',
+        code_verifier: 'codeVerifier',
+      });
+      expect(response).toEqual({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      });
+    });
+
+    it('should return the access token from code (authFormat: basic auth, requestFormat: JSON)', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.AUTHORIZATION_CODE_PKCE,
+        authorizationEndpoint: 'https://auth-server.com/oauth/authorize',
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        redirectUri: 'redirectUri',
+        scopes: ['scope1', 'scope2'],
+        codeVerifier: 'codeVerifier',
+        state: 'random-state',
+        authFormat: AuthFormat.BASIC_AUTH,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      const mockHandler = new MswMockRequestHandler(
+        'https://auth-server.com/oauth/token',
+        async () => {
+          return Response.json({
+            access_token: 'access-token',
+            refresh_token: 'refresh-token',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          });
+        }
+      );
+
+      server.use(mockHandler);
+
+      const response = await client.getAccessTokenFromCode('code');
+
+      const receivedRequest = mockHandler.receivedRequest();
+      expect(receivedRequest?.method).toBe('POST');
+      expect(Object.fromEntries(receivedRequest?.headers as any)).toEqual({
+        accept: 'application/json',
+        'content-type': 'application/json',
+        authorization: 'Basic Y2xpZW50SWQ6Y2xpZW50U2VjcmV0',
+      });
+      expect(await receivedRequest?.json()).toEqual({
+        grant_type: 'authorization_code',
+        code: 'code',
+        redirect_uri: 'redirectUri',
+        code_verifier: 'codeVerifier',
+      });
+      expect(response).toEqual({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      });
+    });
+
+    it('should return the access token from code (authFormat: in body, requestFormat: form)', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.AUTHORIZATION_CODE_PKCE,
+        authorizationEndpoint: 'https://auth-server.com/oauth/authorize',
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        redirectUri: 'redirectUri',
+        scopes: ['scope1', 'scope2'],
+        codeVerifier: 'codeVerifier',
+        state: 'random-state',
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.FORM,
+      });
+
+      const mockHandler = new MswMockRequestHandler(
+        'https://auth-server.com/oauth/token',
+        async () => {
+          return Response.json({
+            access_token: 'access-token',
+            refresh_token: 'refresh-token',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          });
+        }
+      );
+
+      server.use(mockHandler);
+
+      const response = await client.getAccessTokenFromCode('code');
+
+      const receivedRequest = mockHandler.receivedRequest();
+      expect(receivedRequest?.method).toBe('POST');
+      expect(Object.fromEntries(receivedRequest?.headers as any)).toEqual({
+        'content-type': 'application/x-www-form-urlencoded',
+      });
+      expect(await receivedRequest?.text()).toEqual(
+        'grant_type=authorization_code&code=code&redirect_uri=redirectUri&client_id=clientId&client_secret=clientSecret&code_verifier=codeVerifier'
+      );
+      expect(response).toEqual({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      });
+    });
+
+    it('should return the access token from code (authFormat: basic auth, requestFormat: form)', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.AUTHORIZATION_CODE_PKCE,
+        authorizationEndpoint: 'https://auth-server.com/oauth/authorize',
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        redirectUri: 'redirectUri',
+        scopes: ['scope1', 'scope2'],
+        codeVerifier: 'codeVerifier',
+        state: 'random-state',
+        authFormat: AuthFormat.BASIC_AUTH,
+        requestFormat: RequestFormat.FORM,
+      });
+
+      const mockHandler = new MswMockRequestHandler(
+        'https://auth-server.com/oauth/token',
+        async () => {
+          return Response.json({
+            access_token: 'access-token',
+            refresh_token: 'refresh-token',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          });
+        }
+      );
+
+      server.use(mockHandler);
+
+      const response = await client.getAccessTokenFromCode('code');
+
+      const receivedRequest = mockHandler.receivedRequest();
+      expect(receivedRequest?.method).toBe('POST');
+      expect(Object.fromEntries(receivedRequest?.headers as any)).toEqual({
+        'content-type': 'application/x-www-form-urlencoded',
+        authorization: 'Basic Y2xpZW50SWQ6Y2xpZW50U2VjcmV0',
+      });
+      expect(await receivedRequest?.text()).toEqual(
+        'grant_type=authorization_code&code=code&redirect_uri=redirectUri&code_verifier=codeVerifier'
+      );
+      expect(response).toEqual({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      });
+    });
+
+    it('should throw an error if the flow is client credentials', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.CLIENT_CREDENTIALS,
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        scopes: ['scope1', 'scope2'],
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      await expect(client.getAccessTokenFromCode('code')).rejects.toThrow(
+        'Client Credentials flow not supported'
+      );
+    });
+  });
+
+  describe('getAccessTokenFromClientCredentials', () => {
+    it('should return the access token from client credentials (authFormat: in body, requestFormat: JSON)', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.CLIENT_CREDENTIALS,
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        scopes: ['scope1', 'scope2'],
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      const mockHandler = new MswMockRequestHandler(
+        'https://auth-server.com/oauth/token',
+        async () => {
+          return Response.json({
+            access_token: 'access-token',
+            refresh_token: 'refresh-token',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          });
+        }
+      );
+
+      server.use(mockHandler);
+
+      const response = await client.getAccessTokenFromClientCredentials();
+
+      const receivedRequest = mockHandler.receivedRequest();
+      expect(receivedRequest?.method).toBe('POST');
+      expect(Object.fromEntries(receivedRequest?.headers as any)).toEqual({
+        accept: 'application/json',
+        'content-type': 'application/json',
+      });
+      expect(await receivedRequest?.json()).toEqual({
+        grant_type: 'client_credentials',
+        client_id: 'clientId',
+        client_secret: 'clientSecret',
+        scope: 'scope1 scope2',
+      });
+      expect(response).toEqual({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      });
+    });
+
+    it('should return the access token from client credentials (authFormat: basic auth, requestFormat: JSON)', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.CLIENT_CREDENTIALS,
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        scopes: ['scope1', 'scope2'],
+        authFormat: AuthFormat.BASIC_AUTH,
+        requestFormat: RequestFormat.JSON,
+      });
+
+      const mockHandler = new MswMockRequestHandler(
+        'https://auth-server.com/oauth/token',
+        async () => {
+          return Response.json({
+            access_token: 'access-token',
+            refresh_token: 'refresh-token',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          });
+        }
+      );
+
+      server.use(mockHandler);
+
+      const response = await client.getAccessTokenFromClientCredentials();
+
+      const receivedRequest = mockHandler.receivedRequest();
+      expect(receivedRequest?.method).toBe('POST');
+      expect(Object.fromEntries(receivedRequest?.headers as any)).toEqual({
+        accept: 'application/json',
+        'content-type': 'application/json',
+        authorization: 'Basic Y2xpZW50SWQ6Y2xpZW50U2VjcmV0',
+      });
+      expect(await receivedRequest?.json()).toEqual({
+        grant_type: 'client_credentials',
+        scope: 'scope1 scope2',
+      });
+      expect(response).toEqual({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      });
+    });
+
+    it('should return the access token from client credentials (authFormat: in body, requestFormat: form)', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.CLIENT_CREDENTIALS,
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        scopes: ['scope1', 'scope2'],
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.FORM,
+      });
+
+      const mockHandler = new MswMockRequestHandler(
+        'https://auth-server.com/oauth/token',
+        async () => {
+          return Response.json({
+            access_token: 'access-token',
+            refresh_token: 'refresh-token',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          });
+        }
+      );
+
+      server.use(mockHandler);
+
+      const response = await client.getAccessTokenFromClientCredentials();
+
+      const receivedRequest = mockHandler.receivedRequest();
+      expect(receivedRequest?.method).toBe('POST');
+      expect(Object.fromEntries(receivedRequest?.headers as any)).toEqual({
+        'content-type': 'application/x-www-form-urlencoded',
+      });
+      expect(await receivedRequest?.text()).toEqual(
+        'grant_type=client_credentials&client_id=clientId&client_secret=clientSecret&scope=scope1+scope2'
+      );
+      expect(response).toEqual({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      });
+    });
+
+    it('should return the access token from client credentials (authFormat: basic auth, requestFormat: form)', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.CLIENT_CREDENTIALS,
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        scopes: ['scope1', 'scope2'],
+        authFormat: AuthFormat.BASIC_AUTH,
+        requestFormat: RequestFormat.FORM,
+      });
+
+      const mockHandler = new MswMockRequestHandler(
+        'https://auth-server.com/oauth/token',
+        async () => {
+          return Response.json({
+            access_token: 'access-token',
+            refresh_token: 'refresh-token',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          });
+        }
+      );
+
+      server.use(mockHandler);
+
+      const response = await client.getAccessTokenFromClientCredentials();
+
+      const receivedRequest = mockHandler.receivedRequest();
+      expect(receivedRequest?.method).toBe('POST');
+      expect(Object.fromEntries(receivedRequest?.headers as any)).toEqual({
+        'content-type': 'application/x-www-form-urlencoded',
+        authorization: 'Basic Y2xpZW50SWQ6Y2xpZW50U2VjcmV0',
+      });
+      expect(await receivedRequest?.text()).toEqual(
+        'grant_type=client_credentials&scope=scope1+scope2'
+      );
+      expect(response).toEqual({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      });
+    });
+
+    it('should throw an error if the flow is not client credentials', async () => {
+      const client = new OAuth2Client({
+        type: OAuth2Type.AUTHORIZATION_CODE_PKCE,
+        authorizationEndpoint: 'https://auth-server.com/oauth/authorize',
+        tokenEndpoint: 'https://auth-server.com/oauth/token',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        redirectUri: 'redirectUri',
+        scopes: ['scope1', 'scope2'],
+        codeVerifier: 'codeVerifier',
+        state: 'random-state',
+        authFormat: AuthFormat.IN_BODY,
+        requestFormat: RequestFormat.FORM,
+      });
+
+      await expect(client.getAccessTokenFromClientCredentials()).rejects.toThrow(
+        'Only Client Credentials flow is supported'
+      );
+    });
+  });
+
+  // getAuthorizationRedirectResponse
+  // getAccessTokenFromCode
+  // getAccessTokenFromClientCredentials
 });

--- a/packages/altair-core/src/oauth2/client.ts
+++ b/packages/altair-core/src/oauth2/client.ts
@@ -16,7 +16,8 @@ interface CommonOAuth2ClientOptions {
   authFormat: AuthFormat;
   requestFormat: RequestFormat;
 }
-interface AuthorizationCode_OAuth2ClientOptions extends CommonOAuth2ClientOptions {
+export interface AuthorizationCode_OAuth2ClientOptions
+  extends CommonOAuth2ClientOptions {
   type: OAuth2Type.AUTHORIZATION_CODE;
   clientId: string;
   clientSecret: string;
@@ -29,7 +30,7 @@ interface AuthorizationCode_OAuth2ClientOptions extends CommonOAuth2ClientOption
   tokenEndpoint: string;
 }
 
-interface AuthorizationCodePKCE_OAuth2ClientOptions
+export interface AuthorizationCodePKCE_OAuth2ClientOptions
   extends Omit<AuthorizationCode_OAuth2ClientOptions, 'type'> {
   type: OAuth2Type.AUTHORIZATION_CODE_PKCE;
   /**
@@ -39,7 +40,8 @@ interface AuthorizationCodePKCE_OAuth2ClientOptions
   codeVerifier: string;
 }
 
-interface ClientCredentials_OAuth2ClientOptions extends CommonOAuth2ClientOptions {
+export interface ClientCredentials_OAuth2ClientOptions
+  extends CommonOAuth2ClientOptions {
   type: OAuth2Type.CLIENT_CREDENTIALS;
   clientId: string;
   clientSecret: string;

--- a/packages/altair-core/src/oauth2/client.ts
+++ b/packages/altair-core/src/oauth2/client.ts
@@ -1,4 +1,4 @@
-import { getCodeChallenge } from './helpers';
+import { base64EncodeSafe, getCodeChallenge } from './helpers';
 import {
   AccessTokenErrorResponse,
   AccessTokenRequest,
@@ -160,7 +160,7 @@ export class OAuth2Client {
     const headers: HeadersInit = {};
     switch (this.options.authFormat) {
       case AuthFormat.BASIC_AUTH: {
-        headers.Authorization = `Basic ${btoa(
+        headers.Authorization = `Basic ${base64EncodeSafe(
           `${this.options.clientId}:${this.options.clientSecret}`
         )}`;
         break;

--- a/packages/altair-core/src/oauth2/client.ts
+++ b/packages/altair-core/src/oauth2/client.ts
@@ -3,27 +3,32 @@ import {
   AccessTokenErrorResponse,
   AccessTokenRequest,
   AccessTokenResponse,
+  AuthFormat,
   AuthorizationRedirectErrorResponse,
   AuthorizationRedirectResponse,
   AuthorizationRequestParams,
   OAuth2Type,
+  RequestFormat,
 } from './types';
 
 interface CommonOAuth2ClientOptions {
-  clientId: string;
-  redirectUri: string;
   scopes: string[];
+  authFormat: AuthFormat;
+  requestFormat: RequestFormat;
+}
+interface AuthorizationCode_OAuth2ClientOptions extends CommonOAuth2ClientOptions {
+  type: OAuth2Type.AUTHORIZATION_CODE;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
   /**
    * An opaque string used to store request-specific data and/or prevent CSRF attacks by verifying the value of state later
    */
   state: string;
-}
-interface AuthorizationCode_OAuth2ClientOptions extends CommonOAuth2ClientOptions {
-  type: OAuth2Type.AUTHORIZATION_CODE;
-  clientSecret: string;
   authorizationEndpoint: string;
   tokenEndpoint: string;
 }
+
 interface AuthorizationCodePKCE_OAuth2ClientOptions
   extends Omit<AuthorizationCode_OAuth2ClientOptions, 'type'> {
   type: OAuth2Type.AUTHORIZATION_CODE_PKCE;
@@ -33,14 +38,28 @@ interface AuthorizationCodePKCE_OAuth2ClientOptions
    */
   codeVerifier: string;
 }
+
+interface ClientCredentials_OAuth2ClientOptions extends CommonOAuth2ClientOptions {
+  type: OAuth2Type.CLIENT_CREDENTIALS;
+  clientId: string;
+  clientSecret: string;
+  tokenEndpoint: string;
+}
+
 export type OAuth2ClientOptions =
   | AuthorizationCode_OAuth2ClientOptions
-  | AuthorizationCodePKCE_OAuth2ClientOptions;
+  | AuthorizationCodePKCE_OAuth2ClientOptions
+  | ClientCredentials_OAuth2ClientOptions;
 
 export class OAuth2Client {
   constructor(private options: OAuth2ClientOptions) {}
 
   async getAuthorizationUrl(): Promise<string> {
+    if (this.options.type === OAuth2Type.CLIENT_CREDENTIALS) {
+      throw new Error(
+        'Client Credentials flow not supported for authorization code'
+      );
+    }
     const params: AuthorizationRequestParams = {
       response_type: 'code',
       client_id: this.options.clientId,
@@ -63,6 +82,11 @@ export class OAuth2Client {
   async getAuthorizationRedirectResponse(): Promise<
     AuthorizationRedirectResponse | AuthorizationRedirectErrorResponse | undefined
   > {
+    if (this.options.type === OAuth2Type.CLIENT_CREDENTIALS) {
+      throw new Error(
+        'Client Credentials flow not supported for authorization code'
+      );
+    }
     // Get params from url
     const url = new URL(window.location.href);
     const obj = Object.fromEntries(url.searchParams.entries());
@@ -97,23 +121,91 @@ export class OAuth2Client {
   async getAccessTokenFromCode(
     code: string
   ): Promise<AccessTokenResponse | AccessTokenErrorResponse> {
+    if (this.options.type === OAuth2Type.CLIENT_CREDENTIALS) {
+      throw new Error('Client Credentials flow not supported');
+    }
     const params: AccessTokenRequest = {
       grant_type: 'authorization_code',
       code,
       redirect_uri: this.options.redirectUri,
       client_id: this.options.clientId,
-      client_secret: this.options.clientSecret, // TODO: determine if to use basic auth or client_id and client_secret in the body
+      client_secret: this.options.clientSecret,
       ...(this.options.type === 'auth_code_pkce'
         ? { code_verifier: this.options.codeVerifier }
         : {}),
     };
+    return this.makeAccessTokenRequest(params);
+  }
+
+  async getAccessTokenFromClientCredentials(): Promise<
+    AccessTokenResponse | AccessTokenErrorResponse
+  > {
+    if (this.options.type !== OAuth2Type.CLIENT_CREDENTIALS) {
+      throw new Error('Only Client Credentials flow is supported');
+    }
+
+    const params: AccessTokenRequest = {
+      grant_type: 'client_credentials',
+      client_id: this.options.clientId,
+      client_secret: this.options.clientSecret,
+      scope: this.options.scopes.join(' '),
+    };
+
+    return this.makeAccessTokenRequest(params);
+  }
+
+  private getAccessTokenRequestHeaders(): HeadersInit {
+    const headers: HeadersInit = {};
+    switch (this.options.authFormat) {
+      case AuthFormat.BASIC_AUTH: {
+        headers.Authorization = `Basic ${btoa(
+          `${this.options.clientId}:${this.options.clientSecret}`
+        )}`;
+        break;
+      }
+    }
+
+    switch (this.options.requestFormat) {
+      case RequestFormat.JSON: {
+        headers.Accept = 'application/json';
+        headers['Content-Type'] = 'application/json';
+        break;
+      }
+
+      case RequestFormat.FORM: {
+        headers['Content-Type'] = 'application/x-www-form-urlencoded';
+        break;
+      }
+    }
+
+    return headers;
+  }
+
+  private getAccessTokenRequestBody(params: AccessTokenRequest): BodyInit {
+    let bodyParams: Partial<AccessTokenRequest> = structuredClone(params);
+    switch (this.options.authFormat) {
+      case AuthFormat.BASIC_AUTH: {
+        const { client_id, client_secret, ...rest } = params;
+        bodyParams = rest;
+        break;
+      }
+    }
+
+    switch (this.options.requestFormat) {
+      case RequestFormat.JSON:
+        return JSON.stringify(bodyParams);
+      case RequestFormat.FORM:
+        return new URLSearchParams({ ...bodyParams }).toString();
+    }
+  }
+
+  private async makeAccessTokenRequest(
+    params: AccessTokenRequest
+  ): Promise<AccessTokenResponse | AccessTokenErrorResponse> {
     const response = await fetch(this.options.tokenEndpoint, {
       method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(params),
+      headers: this.getAccessTokenRequestHeaders(),
+      body: this.getAccessTokenRequestBody(params),
     });
     const data = await response.json();
     return data;

--- a/packages/altair-core/src/oauth2/helpers.spec.ts
+++ b/packages/altair-core/src/oauth2/helpers.spec.ts
@@ -42,6 +42,16 @@ describe('oauth2 helpers', () => {
         '04aa106279f5977f59f9067fa9712afc4aedc6f5862a8defc34552d8c7206393'
       );
     });
+
+    it('should return expected hash for an empty string', async () => {
+      const out = await sha256('');
+      const hexed = hex(out);
+
+      // https://www.scivision.dev/sha256-hash-empty-file/
+      expect(hexed).toBe(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      );
+    });
   });
 
   describe('getCodeChallenge', () => {

--- a/packages/altair-core/src/oauth2/helpers.spec.ts
+++ b/packages/altair-core/src/oauth2/helpers.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+  base64EncodeSafe,
   base64UrlEncode,
   getCodeChallenge,
   hex,
@@ -12,6 +13,13 @@ describe('oauth2 helpers', () => {
     it('should generate a random string', () => {
       const out = secureRandomString(64);
       expect(out).toHaveLength(64);
+      const out2 = secureRandomString(64);
+      expect(out2).toHaveLength(64);
+      expect(out).not.toBe(out2);
+    });
+    it('should generate a 16 character string by default', () => {
+      const out = secureRandomString();
+      expect(out).toHaveLength(16);
     });
     it('should generate a code verifier spec compliant string', () => {
       const out = secureRandomString(128);
@@ -58,6 +66,21 @@ describe('oauth2 helpers', () => {
     ])('should encode a string to base64url', async (str, expected) => {
       const out = await getCodeChallenge(str);
       expect(out).toBe(expected);
+    });
+  });
+
+  describe('base64EncodeSafe', () => {
+    it('should encode a string to base64', () => {
+      const out = base64EncodeSafe('hello world');
+      expect(out).toBe('aGVsbG8gd29ybGQ=');
+    });
+
+    it('should encode a unicode string to base64', () => {
+      expect(base64EncodeSafe('你好，世界')).toBe('5L2g5aW977yM5LiW55WM');
+
+      expect(base64EncodeSafe('👋🌍')).toBe('8J+Ri/CfjI0=');
+
+      expect(base64EncodeSafe('a Ā 𐀀 文 🦄')).toBe('YSDEgCDwkICAIOaWhyDwn6aE');
     });
   });
 });

--- a/packages/altair-core/src/oauth2/helpers.ts
+++ b/packages/altair-core/src/oauth2/helpers.ts
@@ -7,7 +7,11 @@ export const secureRandomString = (length = 16) => {
     .map((x) => charset[x % charset.length])
     .join('');
 };
-
+export const base64EncodeSafe = (str: string) => {
+  const bytes = new TextEncoder().encode(str);
+  const binStr = Array.from(bytes, (b) => String.fromCodePoint(b)).join('');
+  return btoa(binStr);
+};
 // https://thewoods.blog/base64url/
 export const base64UrlEncode = (buffer: ArrayBuffer): string => {
   return btoa(

--- a/packages/altair-core/src/oauth2/types.ts
+++ b/packages/altair-core/src/oauth2/types.ts
@@ -1,6 +1,17 @@
 export enum OAuth2Type {
   AUTHORIZATION_CODE = 'auth_code',
   AUTHORIZATION_CODE_PKCE = 'auth_code_pkce',
+  CLIENT_CREDENTIALS = 'client_credentials',
+}
+
+export enum AuthFormat {
+  BASIC_AUTH = 'basic',
+  IN_BODY = 'body',
+}
+
+export enum RequestFormat {
+  JSON = 'json',
+  FORM = 'form',
 }
 
 export interface SimpleAuthorizationRequestParams extends Record<string, string> {
@@ -66,9 +77,20 @@ export interface AuthorizationCodePKCE_AccessTokenRequest
   extends AuthorizationCode_AccessTokenRequest {
   code_verifier: string;
 }
+
+// https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/
+export interface ClientCredentials_AccessTokenRequest {
+  grant_type: 'client_credentials';
+  client_id: string;
+  client_secret: string;
+  scope?: string;
+}
+
+// https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
 export type AccessTokenRequest =
   | AuthorizationCode_AccessTokenRequest
-  | AuthorizationCodePKCE_AccessTokenRequest;
+  | AuthorizationCodePKCE_AccessTokenRequest
+  | ClientCredentials_AccessTokenRequest;
 
 export interface AccessTokenResponse {
   /**

--- a/packages/altair-core/src/request/handlers/http.spec.ts
+++ b/packages/altair-core/src/request/handlers/http.spec.ts
@@ -1,56 +1,10 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-  jest,
-} from '@jest/globals';
-import {
-  HttpResponse,
-  http,
-  delay,
-  RequestHandler,
-  HttpResponseResolver,
-  ResponseResolver,
-} from 'msw';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
+import { delay } from 'msw';
 import { setupServer } from 'msw/node';
 import { GraphQLRequestHandler, GraphQLRequestOptions } from '../types';
 import { HttpRequestHandler } from './http';
 import { Observable } from 'rxjs';
-import { QueryResponse } from '../../types/state/query.interfaces';
-import { i } from 'msw/lib/core/HttpResponse-B07UKAkU';
-
-class MswMockRequestHandler extends RequestHandler {
-  private lastRequest?: Request;
-  constructor(path: string, resolver: ResponseResolver) {
-    super({
-      info: {
-        header: `msw request handler-${path}`,
-      },
-      resolver,
-    });
-  }
-  parse(...args: Parameters<RequestHandler['parse']>) {
-    const [{ request }] = args;
-    this.lastRequest = request.clone();
-    return super.parse(...args);
-  }
-  predicate(args: {
-    request: Request;
-    parsedResult: any;
-    resolutionContext?: i | undefined;
-  }): boolean {
-    return true;
-  }
-  log(args: { request: Request; response: Response; parsedResult: any }): void {
-    // throw new Error('Method not implemented.');
-  }
-  receivedRequest() {
-    return this.lastRequest?.clone();
-  }
-}
+import { MswMockRequestHandler } from '../../test-helpers';
 
 const server = setupServer();
 

--- a/packages/altair-core/src/test-helpers.ts
+++ b/packages/altair-core/src/test-helpers.ts
@@ -1,0 +1,31 @@
+import { RequestHandler, ResponseResolver } from 'msw';
+
+export class MswMockRequestHandler extends RequestHandler {
+  private lastRequest?: Request;
+  constructor(path: string, resolver: ResponseResolver) {
+    super({
+      info: {
+        header: `msw request handler-${path}`,
+      },
+      resolver,
+    });
+  }
+  parse(...args: Parameters<RequestHandler['parse']>) {
+    const [{ request }] = args;
+    this.lastRequest = request.clone();
+    return super.parse(...args);
+  }
+  predicate(args: {
+    request: Request;
+    parsedResult: any;
+    resolutionContext?: unknown;
+  }): boolean {
+    return true;
+  }
+  log(args: { request: Request; response: Response; parsedResult: any }): void {
+    // throw new Error('Method not implemented.');
+  }
+  receivedRequest() {
+    return this.lastRequest?.clone();
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,6 +4127,11 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
+"@jedmao/location@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@jedmao/location/-/location-3.0.0.tgz#f2b24e937386f95252f3a1fefbf7ca2e0a4b87e9"
+  integrity sha512-p7mzNlgJbCioUYLUEKds3cQG4CHONVFJNYqMe6ocEtENCL/jYmMo1Q3ApwsMmU+L0ZkaDJEyv4HokaByLoPwlQ==
+
 "@jest/console@^28.1.3":
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-28.1.3.tgz#2030606ec03a18c31803b8a36382762e447655df"


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
Closes #2680 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Implement the OAuth2 client credentials flow in the OAuth2Client class, enabling access token retrieval using client credentials. Enhance the client to support various authentication and request formats, and add tests to ensure functionality across different scenarios.

New Features:
- Implement OAuth2 client credentials flow in the OAuth2Client class, allowing retrieval of access tokens using client credentials.

Enhancements:
- Add support for different authentication and request formats in the OAuth2Client, including basic auth and JSON or form-encoded requests.

Tests:
- Introduce comprehensive tests for the OAuth2 client credentials flow, including scenarios for different authentication and request formats.