### PR TITLE
remove chocolatey installer after installing package

### DIFF
--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -17,3 +17,10 @@ $packageArgs = @{
 }
 
 Install-ChocolateyPackage @packageArgs
+
+try {
+  # Remove the installer
+  Remove-Item $fileLocation -Force -ErrorAction 'SilentlyContinue'
+} catch {
+  Write-Error "Failed to remove the installer: $_"
+}

--- a/chocolatey/tools/chocolateyInstall.ps1
+++ b/chocolatey/tools/chocolateyInstall.ps1
@@ -18,9 +18,5 @@ $packageArgs = @{
 
 Install-ChocolateyPackage @packageArgs
 
-try {
-  # Remove the installer
-  Remove-Item $fileLocation -Force -ErrorAction 'SilentlyContinue'
-} catch {
-  Write-Error "Failed to remove the installer: $_"
-}
+# Remove the installer
+Remove-Item $fileLocation -Force -ErrorAction 'SilentlyContinue'


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
Closes #2173 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Bug Fixes:
- Remove the Chocolatey installer after installing the package to prevent leftover files.