### PR TITLE
verify remote collection before local collection deletion

### DIFF
--- a/packages/altair-app/src/app/modules/altair/services/window.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/window.service.ts
@@ -1,6 +1,6 @@
-import { EMPTY, firstValueFrom, from } from 'rxjs';
+import { EMPTY, firstValueFrom, from, of } from 'rxjs';
 
-import { tap, map, switchMap, take } from 'rxjs/operators';
+import { tap, map, switchMap, take, catchError } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { select, Store } from '@ngrx/store';
 
@@ -512,6 +512,11 @@ export class WindowService {
             return from(
               this.collectionService.getCollectionByID(data.layout.collectionId)
             ).pipe(
+              catchError(() => {
+                // continue to evaluation logic in map() below if collection is not found
+                // (EMPTY would stop the observable chain)
+                return of(undefined);
+              }),
               map((collection) => {
                 if (collection) {
                   const query = collection.queries.find(


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Verify the creation of remote collections before deleting local collections to prevent data loss and handle subcollections during remote collection creation.

Bug Fixes:
- Ensure remote collection is verified before deleting the local collection to prevent data loss.

Enhancements:
- Add handling for subcollections when creating remote collections to ensure all subcollections are also created remotely.