### PR TITLE
inject app theme into plugin instead of styles

### DIFF
--- a/packages/altair-app/src/app/modules/altair/directives/theme/theme.directive.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/directives/theme/theme.directive.spec.ts
@@ -3,7 +3,7 @@ import { mock } from '../../../../../testing';
 
 describe('ThemeDirective', () => {
   it('should create an instance', () => {
-    const directive = new ThemeDirective(mock(), mock());
+    const directive = new ThemeDirective(mock());
     expect(directive).toBeTruthy();
   });
 });

--- a/packages/altair-app/src/app/modules/altair/directives/theme/theme.directive.ts
+++ b/packages/altair-app/src/app/modules/altair/directives/theme/theme.directive.ts
@@ -4,6 +4,7 @@ import {
   hexToRgbStr,
   ICustomTheme,
   ITheme,
+  getCSS,
 } from 'altair-graphql-core/build/theme';
 
 import { css } from '@emotion/css';
@@ -20,10 +21,7 @@ export class ThemeDirective implements OnInit, OnChanges {
 
   private className = '';
 
-  constructor(
-    private themeRegistry: ThemeRegistryService,
-    private nzConfigService: NzConfigService
-  ) {}
+  constructor(private nzConfigService: NzConfigService) {}
 
   ngOnInit() {
     this.applyTheme(this.appTheme, this.appDarkTheme, this.appAccentColor);
@@ -43,118 +41,12 @@ export class ThemeDirective implements OnInit, OnChanges {
     }
   }
 
-  getCssString(theme: ITheme) {
-    return `
-      --baseline-size: ${theme.type.fontSize.base};
-      --rem-base: ${theme.type.fontSize.remBase};
-      --body-font-size: ${theme.type.fontSize.body};
-
-      --app-easing: ${theme.easing};
-
-      --black-color: ${theme.colors.black};
-      --dark-grey-color: ${theme.colors.darkGray};
-      --grey-color: ${theme.colors.gray};
-      --light-grey-color: ${theme.colors.lightGray};
-      --white-color: ${theme.colors.white};
-      --green-color: ${theme.colors.green};
-      --blue-color: ${theme.colors.blue};
-      --cerise-color: ${theme.colors.cerise};
-      --red-color: ${theme.colors.red};
-      --rose-color: ${theme.colors.rose};
-      --orange-color: ${theme.colors.orange};
-      --yellow-color: ${theme.colors.yellow};
-      --light-red-color: ${theme.colors.lightRed};
-      --dark-purple-color: ${theme.colors.darkPurple};
-
-      --primary-color: ${theme.colors.primary};
-      --secondary-color: ${theme.colors.secondary};
-      --tertiary-color: ${theme.colors.tertiary};
-
-      --shadow-bg: rgba(${hexToRgbStr(theme.shadow.color)}, ${theme.shadow.opacity});
-
-      --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", 'Helvetica Neue', Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-
-      --rgb-black: ${hexToRgbStr(theme.colors.black)};
-      --rgb-dark-grey: ${hexToRgbStr(theme.colors.darkGray)};
-      --rgb-grey: ${hexToRgbStr(theme.colors.gray)};
-      --rgb-light-grey: ${hexToRgbStr(theme.colors.lightGray)};
-      --rgb-white: ${hexToRgbStr(theme.colors.white)};
-      --rgb-green: ${hexToRgbStr(theme.colors.green)};
-      --rgb-blue: ${hexToRgbStr(theme.colors.blue)};
-      --rgb-cerise: ${hexToRgbStr(theme.colors.cerise)};
-      --rgb-red: ${hexToRgbStr(theme.colors.red)};
-      --rgb-orange: ${hexToRgbStr(theme.colors.orange)};
-      --rgb-yellow: ${hexToRgbStr(theme.colors.yellow)};
-      --rgb-light-red: ${hexToRgbStr(theme.colors.lightRed)};
-      --rgb-dark-purple: ${hexToRgbStr(theme.colors.darkPurple)};
-
-      --editor-font-family: ${theme.editor.fontFamily.default};
-      --editor-font-size: ${theme.editor.fontSize};
-
-      --theme-bg-color: ${theme.colors.bg};
-      --theme-off-bg-color: ${theme.colors.offBg};
-      --theme-font-color: ${theme.colors.font};
-      --theme-off-font-color: ${theme.colors.offFont};
-      --theme-border-color: ${theme.colors.border};
-      --theme-off-border-color: ${theme.colors.offBorder};
-      --header-bg-color: ${theme.colors.headerBg || theme.colors.offBg};
-
-      --rgb-primary: ${hexToRgbStr(theme.colors.primary)};
-      --rgb-secondary: ${hexToRgbStr(theme.colors.secondary)};
-      --rgb-tertiary: ${hexToRgbStr(theme.colors.tertiary)};
-
-      --rgb-theme-bg: ${hexToRgbStr(theme.colors.bg)};
-      --rgb-theme-off-bg: ${hexToRgbStr(theme.colors.offBg)};
-      --rgb-theme-font: ${hexToRgbStr(theme.colors.font)};
-      --rgb-theme-off-font: ${hexToRgbStr(theme.colors.offFont)};
-      --rgb-theme-border: ${hexToRgbStr(theme.colors.border)};
-      --rgb-theme-off-border: ${hexToRgbStr(theme.colors.offBorder)};
-      --rgb-header-bg: ${hexToRgbStr(theme.colors.headerBg || theme.colors.offBg)};
-
-      --editor-comment-color: ${theme.editor.colors.comment};
-      --editor-string-color: ${theme.editor.colors.string};
-      --editor-number-color: ${theme.editor.colors.number};
-      --editor-variable-color: ${theme.editor.colors.variable};
-      --editor-attribute-color: ${theme.editor.colors.attribute};
-      --editor-keyword-color: ${theme.editor.colors.keyword};
-      --editor-atom-color: ${theme.editor.colors.atom};
-      --editor-property-color: ${theme.editor.colors.property};
-      --editor-punctuation-color: ${theme.editor.colors.punctuation};
-      --editor-cursor-color: ${theme.editor.colors.cursor};
-      --editor-def-color: ${theme.editor.colors.definition};
-      --editor-builtin-color: ${theme.editor.colors.builtin};
-    `;
-  }
-
   getDynamicClassName(
     appTheme: ICustomTheme,
     appDarkTheme?: ICustomTheme,
     accentColor?: string
   ) {
-    const extraTheme = accentColor ? { colors: { primary: accentColor } } : {};
-    if (appTheme && appDarkTheme) {
-      return css(`
-        ${this.getCssString(createTheme(appTheme, extraTheme))}
-        @media (prefers-color-scheme: dark) {
-          ${this.getCssString(createTheme(appDarkTheme, extraTheme))}
-        }
-      `);
-    }
-
-    if (!appTheme || appTheme.isSystem) {
-      return css(`
-        ${this.getCssString(
-          createTheme(this.themeRegistry.getTheme('light')!, appTheme, extraTheme)
-        )}
-        @media (prefers-color-scheme: dark) {
-          ${this.getCssString(
-            createTheme(this.themeRegistry.getTheme('dark')!, appTheme, extraTheme)
-          )}
-        }
-      `);
-    }
-
-    return css(this.getCssString(createTheme(appTheme, extraTheme)));
+    return css(getCSS(appTheme, appDarkTheme, accentColor));
   }
 
   applyTheme(theme: ICustomTheme, darkTheme?: ICustomTheme, accentColor?: string) {

--- a/packages/altair-app/src/app/modules/altair/services/plugin/context/plugin-context.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/plugin/context/plugin-context.service.ts
@@ -314,7 +314,19 @@ export class PluginContextService implements PluginContextGenerator {
           const sanitized = DOMPurify.default.sanitize(manifest.icon.src);
           iconSvg = self.sanitizer.bypassSecurityTrustHtml(sanitized);
         }
-        const engine = new PluginParentEngine(panelWorker);
+
+        const settings = await firstValueFrom(
+          self.store.select('settings').pipe(take(1))
+        );
+        const selectedTheme = self.themeRegistryService.getTheme(settings.theme) || {
+          isSystem: true,
+        };
+        const settingsThemeConfig = settings.themeConfig || {};
+        const theme = self.themeRegistryService.mergeThemes(
+          selectedTheme,
+          settingsThemeConfig
+        );
+        const engine = new PluginParentEngine(panelWorker, { theme });
         const panel = new AltairPanel(
           title,
           panelWorker.getIframe(),

--- a/packages/altair-core/src/plugin/v3/panel.ts
+++ b/packages/altair-core/src/plugin/v3/panel.ts
@@ -1,9 +1,11 @@
+import { ICustomTheme, getCSS } from '../../theme';
 import { PluginV3Context } from './context';
 
 interface StylesData {
   styleUrls: string[];
   styles: string[];
   htmlClasses: string[];
+  theme?: ICustomTheme;
 }
 export abstract class AltairV3Panel {
   abstract create(ctx: PluginV3Context, container: HTMLElement): void;
@@ -35,7 +37,11 @@ export abstract class AltairV3Panel {
       document.head.appendChild(link);
     });
 
-    this.injectCSS(data.styles.join('\n'));
+    if (data.styles.length) {
+      this.injectCSS(data.styles.join('\n'));
+    } else if (data.theme) {
+      this.injectCSS(getCSS(data.theme));
+    }
 
     // set the background color of the panel to the theme background color
     this.injectCSS(`
@@ -51,7 +57,7 @@ export abstract class AltairV3Panel {
 
   private injectCSS(css: string) {
     let el = document.createElement('style');
-    el.innerText = css;
+    el.innerText = css.replace(/[\n\r]/g, '');
     document.head.appendChild(el);
     return el;
   }

--- a/packages/altair-core/src/theme/css.ts
+++ b/packages/altair-core/src/theme/css.ts
@@ -1,0 +1,115 @@
+import lightTheme from './defaults/light';
+import darkTheme from './defaults/dark';
+import { ICustomTheme, ITheme, createTheme, hexToRgbStr } from './theme';
+
+const asCSSVariablesString = (theme: ITheme) => {
+  return `
+  :root {
+    --baseline-size: ${theme.type.fontSize.base};
+    --rem-base: ${theme.type.fontSize.remBase};
+    --body-font-size: ${theme.type.fontSize.body};
+
+    --app-easing: ${theme.easing};
+
+    --black-color: ${theme.colors.black};
+    --dark-grey-color: ${theme.colors.darkGray};
+    --grey-color: ${theme.colors.gray};
+    --light-grey-color: ${theme.colors.lightGray};
+    --white-color: ${theme.colors.white};
+    --green-color: ${theme.colors.green};
+    --blue-color: ${theme.colors.blue};
+    --cerise-color: ${theme.colors.cerise};
+    --red-color: ${theme.colors.red};
+    --rose-color: ${theme.colors.rose};
+    --orange-color: ${theme.colors.orange};
+    --yellow-color: ${theme.colors.yellow};
+    --light-red-color: ${theme.colors.lightRed};
+    --dark-purple-color: ${theme.colors.darkPurple};
+
+    --primary-color: ${theme.colors.primary};
+    --secondary-color: ${theme.colors.secondary};
+    --tertiary-color: ${theme.colors.tertiary};
+
+    --shadow-bg: rgba(${hexToRgbStr(theme.shadow.color)}, ${theme.shadow.opacity});
+
+    --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", 'Helvetica Neue', Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+    --rgb-black: ${hexToRgbStr(theme.colors.black)};
+    --rgb-dark-grey: ${hexToRgbStr(theme.colors.darkGray)};
+    --rgb-grey: ${hexToRgbStr(theme.colors.gray)};
+    --rgb-light-grey: ${hexToRgbStr(theme.colors.lightGray)};
+    --rgb-white: ${hexToRgbStr(theme.colors.white)};
+    --rgb-green: ${hexToRgbStr(theme.colors.green)};
+    --rgb-blue: ${hexToRgbStr(theme.colors.blue)};
+    --rgb-cerise: ${hexToRgbStr(theme.colors.cerise)};
+    --rgb-red: ${hexToRgbStr(theme.colors.red)};
+    --rgb-orange: ${hexToRgbStr(theme.colors.orange)};
+    --rgb-yellow: ${hexToRgbStr(theme.colors.yellow)};
+    --rgb-light-red: ${hexToRgbStr(theme.colors.lightRed)};
+    --rgb-dark-purple: ${hexToRgbStr(theme.colors.darkPurple)};
+
+    --editor-font-family: ${theme.editor.fontFamily.default};
+    --editor-font-size: ${theme.editor.fontSize};
+
+    --theme-bg-color: ${theme.colors.bg};
+    --theme-off-bg-color: ${theme.colors.offBg};
+    --theme-font-color: ${theme.colors.font};
+    --theme-off-font-color: ${theme.colors.offFont};
+    --theme-border-color: ${theme.colors.border};
+    --theme-off-border-color: ${theme.colors.offBorder};
+    --header-bg-color: ${theme.colors.headerBg || theme.colors.offBg};
+
+    --rgb-primary: ${hexToRgbStr(theme.colors.primary)};
+    --rgb-secondary: ${hexToRgbStr(theme.colors.secondary)};
+    --rgb-tertiary: ${hexToRgbStr(theme.colors.tertiary)};
+
+    --rgb-theme-bg: ${hexToRgbStr(theme.colors.bg)};
+    --rgb-theme-off-bg: ${hexToRgbStr(theme.colors.offBg)};
+    --rgb-theme-font: ${hexToRgbStr(theme.colors.font)};
+    --rgb-theme-off-font: ${hexToRgbStr(theme.colors.offFont)};
+    --rgb-theme-border: ${hexToRgbStr(theme.colors.border)};
+    --rgb-theme-off-border: ${hexToRgbStr(theme.colors.offBorder)};
+    --rgb-header-bg: ${hexToRgbStr(theme.colors.headerBg || theme.colors.offBg)};
+
+    --editor-comment-color: ${theme.editor.colors.comment};
+    --editor-string-color: ${theme.editor.colors.string};
+    --editor-number-color: ${theme.editor.colors.number};
+    --editor-variable-color: ${theme.editor.colors.variable};
+    --editor-attribute-color: ${theme.editor.colors.attribute};
+    --editor-keyword-color: ${theme.editor.colors.keyword};
+    --editor-atom-color: ${theme.editor.colors.atom};
+    --editor-property-color: ${theme.editor.colors.property};
+    --editor-punctuation-color: ${theme.editor.colors.punctuation};
+    --editor-cursor-color: ${theme.editor.colors.cursor};
+    --editor-def-color: ${theme.editor.colors.definition};
+    --editor-builtin-color: ${theme.editor.colors.builtin};
+  }
+  `;
+};
+
+export const getCSS = (
+  appTheme: ICustomTheme,
+  appDarkTheme?: ICustomTheme,
+  accentColor?: string
+) => {
+  const extraTheme = accentColor ? { colors: { primary: accentColor } } : {};
+  if (appTheme && appDarkTheme) {
+    return `
+      ${asCSSVariablesString(createTheme(appTheme, extraTheme))}
+      @media (prefers-color-scheme: dark) {
+        ${asCSSVariablesString(createTheme(appDarkTheme, extraTheme))}
+      }
+    `;
+  }
+
+  if (!appTheme || appTheme.isSystem) {
+    return `
+      ${asCSSVariablesString(createTheme(lightTheme, appTheme, extraTheme))}
+      @media (prefers-color-scheme: dark) {
+        ${asCSSVariablesString(createTheme(darkTheme, appTheme, extraTheme))}
+      }
+    `;
+  }
+
+  return asCSSVariablesString(createTheme(appTheme, extraTheme));
+};

--- a/packages/altair-core/src/theme/index.ts
+++ b/packages/altair-core/src/theme/index.ts
@@ -3,6 +3,7 @@ import darkTheme from './defaults/dark';
 import draculaTheme from './defaults/dracula';
 
 export * from './theme';
+export * from './css';
 export const light = lightTheme;
 export const dark = darkTheme;
 export const dracula = draculaTheme;


### PR DESCRIPTION
Accessing stylesheet in a cross origin context fails with an error

```
Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules
```

The only reason we did this was to get the current theme of the app from the styles. However we can achieve the same thing if we pass the theme to the plugin for the plugin to create the styles itself/

### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->