### PR TITLE
Fix disabling hardware acceleration

### DIFF
--- a/packages/altair-core/src/plugin/v3/parent-engine.ts
+++ b/packages/altair-core/src/plugin/v3/parent-engine.ts
@@ -125,7 +125,7 @@ export class PluginParentEngine {
       const htmlClasses = Array.from(document.documentElement.classList);
       // Get the styles that are applicable to the current theme of the page
       // Doesn't work crossorigin cases. e.g. when loading from CDN. Fallback to theme instead.
-      const styles = getCssStyles(htmlClasses);
+      const styles = getCssStyles(htmlClasses).filter((s) => s.trim().length > 0);
 
       return { styleUrls, styles, htmlClasses, theme: this.opts?.theme };
     });

--- a/packages/altair-electron-interop/src/settings.ts
+++ b/packages/altair-electron-interop/src/settings.ts
@@ -5,6 +5,7 @@ export interface SettingStore {
     proxy_host?: string;
     proxy_port?: string;
   };
+  disable_hardware_acceleration: boolean;
 }
 
 export const settingsStoreFileName = 'desktop_settings';

--- a/packages/altair-electron/src/app/menu.ts
+++ b/packages/altair-electron/src/app/menu.ts
@@ -1,5 +1,7 @@
 import { app, Menu, MenuItemConstructorOptions, shell } from 'electron';
 import { ActionManager } from './actions';
+import { getStartupOption, setStartupOption } from '../utils/startup';
+import { restartApp } from '../utils';
 
 export class MenuManager {
   constructor(private actionManager: ActionManager) {
@@ -104,15 +106,21 @@ export class MenuManager {
         submenu: [
           { role: 'minimize' },
           { role: 'close' },
-          {
-            label: 'Disable hardware acceleration (beta)',
-            click: () => {
-              app.commandLine.appendSwitch('ignore-gpu-blacklist');
-              app.commandLine.appendSwitch('disable-gpu');
-              app.commandLine.appendSwitch('disable-gpu-compositing');
-              app.disableHardwareAcceleration();
-            },
-          },
+          getStartupOption('DISABLE_HARDWARE_ACCELERATION')
+            ? {
+                label: 'Enable hardware acceleration (beta)',
+                click: () => {
+                  setStartupOption('DISABLE_HARDWARE_ACCELERATION', false);
+                  restartApp(app);
+                },
+              }
+            : {
+                label: 'Disable hardware acceleration (beta)',
+                click: () => {
+                  setStartupOption('DISABLE_HARDWARE_ACCELERATION', true);
+                  restartApp(app);
+                },
+              },
           ...(isMac
             ? ([
                 { role: 'minimize' },

--- a/packages/altair-electron/src/app/menu.ts
+++ b/packages/altair-electron/src/app/menu.ts
@@ -1,6 +1,9 @@
 import { app, Menu, MenuItemConstructorOptions, shell } from 'electron';
 import { ActionManager } from './actions';
-import { getStartupOption, setStartupOption } from '../utils/startup';
+import {
+  getDisableHardwareAcceleration,
+  setDisableHardwareAcceleration,
+} from '../utils/startup';
 import { restartApp } from '../utils';
 
 export class MenuManager {
@@ -106,18 +109,18 @@ export class MenuManager {
         submenu: [
           { role: 'minimize' },
           { role: 'close' },
-          getStartupOption('DISABLE_HARDWARE_ACCELERATION')
+          getDisableHardwareAcceleration()
             ? {
                 label: 'Enable hardware acceleration (beta)',
                 click: () => {
-                  setStartupOption('DISABLE_HARDWARE_ACCELERATION', false);
+                  setDisableHardwareAcceleration(false);
                   restartApp(app);
                 },
               }
             : {
                 label: 'Disable hardware acceleration (beta)',
                 click: () => {
-                  setStartupOption('DISABLE_HARDWARE_ACCELERATION', true);
+                  setDisableHardwareAcceleration(true);
                   restartApp(app);
                 },
               },

--- a/packages/altair-electron/src/index.ts
+++ b/packages/altair-electron/src/index.ts
@@ -2,10 +2,12 @@ import unhandled from 'electron-unhandled';
 import * as Sentry from '@sentry/electron';
 import { ElectronApp } from './app';
 import { app } from 'electron';
+import { configureAppOnStartup } from './utils/startup';
 
 Sentry.init({
   dsn: 'https://1b08762f991476e3115e1ab7d12e6682@o4506180788879360.ingest.sentry.io/4506198594813952',
   release: app.getVersion(),
 });
+configureAppOnStartup(app);
 new ElectronApp();
 unhandled({ showDialog: false });

--- a/packages/altair-electron/src/settings/main/store.ts
+++ b/packages/altair-electron/src/settings/main/store.ts
@@ -9,6 +9,12 @@ import { SettingsState } from 'altair-static';
 
 export const store = new ElectronStore<SettingStore>({
   name: settingsStoreFileName,
+  defaults: {
+    settings: {
+      proxy_setting: 'none',
+    },
+    disable_hardware_acceleration: false,
+  },
 });
 
 export const altairSettingsStore = new ElectronStore<SettingsState>({

--- a/packages/altair-electron/src/store.ts
+++ b/packages/altair-electron/src/store.ts
@@ -30,4 +30,6 @@ export class InMemoryStore {
   }
 }
 
-export class PersistentStore extends ElectronStore {}
+export class PersistentStore<
+  T extends Record<string, any> = Record<string, unknown>,
+> extends ElectronStore<T> {}

--- a/packages/altair-electron/src/utils/index.ts
+++ b/packages/altair-electron/src/utils/index.ts
@@ -2,7 +2,7 @@
 import { readdir } from 'fs';
 import fs from 'fs';
 import { join } from 'path';
-import { ipcMain } from 'electron';
+import { App, ipcMain } from 'electron';
 import { ALTAIR_CUSTOM_PROTOCOL } from '@altairgraphql/electron-interop';
 
 export const getDirectoriesInDirectory = (path: string) => {
@@ -12,8 +12,8 @@ export const getDirectoriesInDirectory = (path: string) => {
         ? reject(err)
         : resolve(
             dirents
-              .filter(dirent => dirent.isDirectory())
-              .map(dirent => dirent.name)
+              .filter((dirent) => dirent.isDirectory())
+              .map((dirent) => dirent.name)
           )
     );
   });
@@ -21,7 +21,7 @@ export const getDirectoriesInDirectory = (path: string) => {
 
 export const deleteFolderRecursive = (path: string) => {
   if (fs.existsSync(path)) {
-    fs.readdirSync(path).forEach(file => {
+    fs.readdirSync(path).forEach((file) => {
       const curPath = join(path, file);
       if (fs.lstatSync(curPath).isDirectory()) {
         // recurse
@@ -62,5 +62,10 @@ export const handleWithCustomErrors = (
 // We don't know the exact position of the URL is in argv. Chromium might inject its own arguments
 // into argv. See https://www.electronjs.org/docs/latest/api/app#event-second-instance.
 export function findCustomProtocolUrlInArgv(argv: string[]) {
-  return argv.find(arg => arg.startsWith(`${ALTAIR_CUSTOM_PROTOCOL}://`));
+  return argv.find((arg) => arg.startsWith(`${ALTAIR_CUSTOM_PROTOCOL}://`));
+}
+
+export function restartApp(app: App) {
+  app.relaunch();
+  app.exit();
 }

--- a/packages/altair-electron/src/utils/startup.ts
+++ b/packages/altair-electron/src/utils/startup.ts
@@ -1,0 +1,32 @@
+import { App } from 'electron';
+import { PersistentStore } from '../store';
+
+interface StartupOptionsStore {
+  DISABLE_HARDWARE_ACCELERATION: boolean;
+}
+const startupOptionsStore = new PersistentStore<StartupOptionsStore>({
+  defaults: {
+    DISABLE_HARDWARE_ACCELERATION: false,
+  },
+});
+function disableHardwareAcceleration(app: App) {
+  app.commandLine.appendSwitch('ignore-gpu-blacklist');
+  app.commandLine.appendSwitch('disable-gpu');
+  app.commandLine.appendSwitch('disable-gpu-compositing');
+  app.disableHardwareAcceleration();
+}
+export function getStartupOption<T extends keyof StartupOptionsStore>(option: T) {
+  return startupOptionsStore.get(option);
+}
+export function setStartupOption<T extends keyof StartupOptionsStore>(
+  option: T,
+  value: StartupOptionsStore[T]
+) {
+  startupOptionsStore.set(option, value);
+}
+
+export function configureAppOnStartup(app: App) {
+  if (startupOptionsStore.get('DISABLE_HARDWARE_ACCELERATION')) {
+    disableHardwareAcceleration(app);
+  }
+}

--- a/packages/altair-electron/src/utils/startup.ts
+++ b/packages/altair-electron/src/utils/startup.ts
@@ -1,32 +1,21 @@
 import { App } from 'electron';
-import { PersistentStore } from '../store';
+import { store } from '../settings/main/store';
 
-interface StartupOptionsStore {
-  DISABLE_HARDWARE_ACCELERATION: boolean;
-}
-const startupOptionsStore = new PersistentStore<StartupOptionsStore>({
-  defaults: {
-    DISABLE_HARDWARE_ACCELERATION: false,
-  },
-});
 function disableHardwareAcceleration(app: App) {
   app.commandLine.appendSwitch('ignore-gpu-blacklist');
   app.commandLine.appendSwitch('disable-gpu');
   app.commandLine.appendSwitch('disable-gpu-compositing');
   app.disableHardwareAcceleration();
 }
-export function getStartupOption<T extends keyof StartupOptionsStore>(option: T) {
-  return startupOptionsStore.get(option);
+export function getDisableHardwareAcceleration() {
+  return store.get('disable_hardware_acceleration');
 }
-export function setStartupOption<T extends keyof StartupOptionsStore>(
-  option: T,
-  value: StartupOptionsStore[T]
-) {
-  startupOptionsStore.set(option, value);
+export function setDisableHardwareAcceleration(value: boolean) {
+  store.set('disable_hardware_acceleration', value);
 }
 
 export function configureAppOnStartup(app: App) {
-  if (startupOptionsStore.get('DISABLE_HARDWARE_ACCELERATION')) {
+  if (store.get('disable_hardware_acceleration')) {
     disableHardwareAcceleration(app);
   }
 }


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Fix the issue with disabling hardware acceleration by implementing a persistent store for startup options and ensuring the application restarts to apply changes. Enhance the codebase by refactoring startup option management to improve maintainability.

Bug Fixes:
- Fix the toggling of hardware acceleration by introducing persistent storage for the option and ensuring the app restarts to apply changes.

Enhancements:
- Refactor the code to use a persistent store for managing startup options, improving the maintainability and scalability of the application settings.