### PR TITLE
updated electron to v33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /app
 COPY .gitignore .gitignore
 # FIXME: running yarn install with --ignore-scripts means that some packages may not get built correctly. Skipping these steps for now.
 # COPY --from=builder /app/out/json/ .
-COPY --from=builder /app/out/yarn.lock ./yarn.lock
+# COPY --from=builder /app/out/yarn.lock ./yarn.lock
 # # install node_modules without running scripts (scripts depend on the source files)
 # RUN yarn install --ignore-scripts
 # Build the project and its dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /app
 COPY .gitignore .gitignore
 # FIXME: running yarn install with --ignore-scripts means that some packages may not get built correctly. Skipping these steps for now.
 # COPY --from=builder /app/out/json/ .
-# COPY --from=builder /app/out/yarn.lock ./yarn.lock
+COPY --from=builder /app/out/yarn.lock ./yarn.lock
 # # install node_modules without running scripts (scripts depend on the source files)
 # RUN yarn install --ignore-scripts
 # Build the project and its dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY CHECKS CHECKS
 # Somehow get an unknown error if I don't install nx first
 RUN yarn add nx -W
 # yarn install 2> >(grep -v warning 1>&2)
-RUN yarn
+RUN yarn install --frozen-lockfile
 RUN yarn turbo run build --filter=@altairgraphql/api...
 
 # ===

--- a/packages/altair-api/package.json
+++ b/packages/altair-api/package.json
@@ -46,7 +46,7 @@
     "@nestjs/schematics": "^10.1.2",
     "@nestjs/testing": "^10.3.10",
     "@types/bcrypt": "^5.0.2",
-    "@types/express": "^4.17.13",
+    "@types/express": "4.17.13",
     "@types/jest": "^28.1.8",
     "@types/newrelic": "^9.14.4",
     "@types/node": "^20.14.10",

--- a/packages/altair-electron/package.json
+++ b/packages/altair-electron/package.json
@@ -42,7 +42,7 @@
     "altair-graphql-core": "^8.0.4",
     "devtron": "^1.4.0",
     "dotenv": "^8.1.0",
-    "electron": "^27.1.0",
+    "electron": "^33.2.1",
     "electron-builder": "^23.6.0",
     "electron-builder-notarize": "^1.2.0",
     "electron-chromedriver": "^14.0.0",

--- a/packages/altair-electron/src/app/index.ts
+++ b/packages/altair-electron/src/app/index.ts
@@ -10,7 +10,7 @@ import {
   ALTAIR_CUSTOM_PROTOCOL,
   IPC_EVENT_NAMES,
 } from '@altairgraphql/electron-interop';
-import { log } from '../utils/log';
+import { error, log } from '../utils/log';
 import { findCustomProtocolUrlInArgv } from '../utils';
 
 export class ElectronApp {
@@ -191,6 +191,14 @@ export class ElectronApp {
         }
         return { action: 'deny' };
       });
+    });
+
+    app.on('render-process-gone', (event, webContents, details) => {
+      error('Render process gone', details);
+    });
+
+    app.on('child-process-gone', (event, details) => {
+      error('Child process gone', details);
     });
   }
 

--- a/packages/altair-electron/src/app/window.ts
+++ b/packages/altair-electron/src/app/window.ts
@@ -34,7 +34,7 @@ import {
 } from '@altairgraphql/electron-interop';
 import { HeaderState } from 'altair-graphql-core/build/types/state/header.interfaces';
 import validateAppSettings from 'altair-graphql-core/build/validate-settings';
-import { log } from '../utils/log';
+import { error, log } from '../utils/log';
 import { ElectronApp } from './index';
 import {
   getAltairSettingsFromFile,
@@ -296,10 +296,7 @@ export class WindowManager {
           return callback({ responseHeaders: details.responseHeaders });
         }
       } catch {}
-      if (
-        details.resourceType === 'mainFrame' ||
-        details.resourceType === 'subFrame'
-      ) {
+      if (['mainFrame', 'subFrame'].includes(details.resourceType)) {
         // Set the CSP
         const scriptSrc = [
           `'self'`,
@@ -353,6 +350,10 @@ export class WindowManager {
       this.instance.show();
       this.instance.focus();
       checkMultipleDataVersions(this.instance);
+    });
+
+    this.instance.webContents.on('render-process-gone', (e, details) => {
+      error('render process gone', details);
     });
   }
 

--- a/packages/altair-electron/src/utils/log.ts
+++ b/packages/altair-electron/src/utils/log.ts
@@ -2,3 +2,7 @@
 export const log = (...args: unknown[]) => {
   console.log(...args);
 };
+
+export const error = (...args: unknown[]) => {
+  console.error(...args);
+};

--- a/packages/altair-express-middleware/package.json
+++ b/packages/altair-express-middleware/package.json
@@ -9,7 +9,7 @@
     "express": "^4.19.2"
   },
   "devDependencies": {
-    "@types/express": "^4.17.13",
+    "@types/express": "4.17.13",
     "@types/node": "^14.14.41",
     "eslint-config-altair": "^8.0.4",
     "nodemon": "^2.0.2",

--- a/packages/gatsby-plugin-altair-graphql/package.json
+++ b/packages/gatsby-plugin-altair-graphql/package.json
@@ -8,7 +8,7 @@
     "altair-express-middleware": "^8.0.4"
   },
   "devDependencies": {
-    "@types/express": "^4.17.13",
+    "@types/express": "4.17.13",
     "express": "^4.19.2",
     "typescript": "5.2.2"
   },

--- a/test-server/package.json
+++ b/test-server/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/compression": "^1.7.0",
-    "@types/express": "^4.17.13",
+    "@types/express": "4.17.13",
     "@types/graphql": "^14.2.0",
     "@types/graphql-upload": "^16.0.7",
     "@types/lodash": "^4.14.123",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27437,10 +27437,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-oauth@0.9.x:
-  version "0.9.15"
-  resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.9.15.tgz#bd1fefaf686c96b75475aed5196412ff60cfb9c1"
-  integrity sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==
+oauth@0.10.0, oauth@0.9.x:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.10.0.tgz#3551c4c9b95c53ea437e1e21e46b649482339c58"
+  integrity sha512-1orQ9MT1vHFGQxhuy7E/0gECD3fd2fCC+PIX+/jgmU/gI3EpRocXtmtvxCO5x3WZ443FLTLFWNDjl5MPJf9u+Q==
 
 object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -35991,15 +35991,10 @@ xxhashjs@~0.2.2:
   dependencies:
     cuint "^0.2.2"
 
-y18n@^4.0.0:
+y18n@4.0.1, y18n@^4.0.0, y18n@^5.0.5:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
-
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yaeti@^0.0.6:
   version "0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8674,6 +8674,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.10.tgz#73c9480791e3ddeb4887a660fc93a7f59353ad45"
   integrity sha512-vwzFiiy8Rn6E0MtA13/Cxxgpan/N6UeNYR9oUu6kuJWxu6zCk98trcDp8CBhbtaeuq9SykCmXkFr2lWLoPcvLg==
 
+"@types/node@^20.9.0":
+  version "20.17.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.9.tgz#5f141d4b7ee125cdee5faefe28de095398865bab"
+  integrity sha512-0JOXkRyLanfGPE2QRCwgxhzlBAvaRdCNMcvbd7jFfpmD4eEXll7LRwy5ymJmyeZqk7Nh7eD2LeUyQ68BbndmXw==
+  dependencies:
+    undici-types "~6.19.2"
+
 "@types/node@^8.0.0":
   version "8.10.66"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"
@@ -16351,6 +16358,15 @@ electron@^27.1.0:
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"
+    extract-zip "^2.0.1"
+
+electron@^33.2.1:
+  version "33.2.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-33.2.1.tgz#d0d7bba7a7abf4f14881d0a6e03c498b301a2d5f"
+  integrity sha512-SG/nmSsK9Qg1p6wAW+ZfqU+AV8cmXMTIklUL18NnOKfZLlum4ZsDoVdmmmlL39ZmeCaq27dr7CgslRPahfoVJg==
+  dependencies:
+    "@electron/get" "^2.0.0"
+    "@types/node" "^20.9.0"
     extract-zip "^2.0.1"
 
 emittery@^0.13.1:
@@ -27421,10 +27437,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-oauth@0.10.0, oauth@0.9.x:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.10.0.tgz#3551c4c9b95c53ea437e1e21e46b649482339c58"
-  integrity sha512-1orQ9MT1vHFGQxhuy7E/0gECD3fd2fCC+PIX+/jgmU/gI3EpRocXtmtvxCO5x3WZ443FLTLFWNDjl5MPJf9u+Q==
+oauth@0.9.x:
+  version "0.9.15"
+  resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.9.15.tgz#bd1fefaf686c96b75475aed5196412ff60cfb9c1"
+  integrity sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==
 
 object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -34294,6 +34310,11 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+
 undici@5.27.2:
   version "5.27.2"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.27.2.tgz#a270c563aea5b46cc0df2550523638c95c5d4411"
@@ -35970,10 +35991,15 @@ xxhashjs@~0.2.2:
   dependencies:
     cuint "^0.2.2"
 
-y18n@4.0.1, y18n@^4.0.0, y18n@^5.0.5:
+y18n@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yaeti@^0.0.6:
   version "0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8155,7 +8155,7 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@*", "@types/express@^4.17.13":
+"@types/express@*", "@types/express@4.17.13", "@types/express@^4.17.13":
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
   integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Update Electron to version 33.2.1 and enhance error logging for process termination events.

Enhancements:
- Add error logging for 'render-process-gone' and 'child-process-gone' events in Electron app.

Build:
- Update Electron dependency to version 33.2.1 in package.json.