### PR TITLE
fix to respect the title configuration for the base environment

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/header/header.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/header/header.component.html
@@ -68,7 +68,7 @@
       @if (activeEnvironment === undefined) {
         <span>
           <app-icon name="eye-off"></app-icon>
-          <span>{{ environments?.base?.title ?? ('NO_ENVIRONMENT_TEXT' | translate) }}</span>
+          <span>{{ ('NO_ENVIRONMENT_TEXT' | translate) }}</span>
         </span>
       }
     </li>
@@ -90,7 +90,7 @@
             nz-menu-item
             (click)="selectActiveEnvironmentChange.emit(undefined)"
             >
-            {{ environments?.base?.title ?? ('NO_ENVIRONMENT_TEXT' | translate) }}
+            {{ ('NO_ENVIRONMENT_TEXT' | translate) }}
           </li>
           <li nz-menu-divider></li>
         }

--- a/packages/altair-app/src/app/modules/altair/components/header/header.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/header/header.component.html
@@ -90,7 +90,12 @@
             nz-menu-item
             (click)="selectActiveEnvironmentChange.emit(undefined)"
             >
-            {{ 'NO_ENVIRONMENT_TEXT' | translate }}
+            @if (environments?.base?.title) {
+              {{ environments.base.title }}
+            }
+            @else {
+              {{ 'NO_ENVIRONMENT_TEXT' | translate }}
+            }
           </li>
           <li nz-menu-divider></li>
         }

--- a/packages/altair-app/src/app/modules/altair/components/header/header.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/header/header.component.html
@@ -68,7 +68,7 @@
       @if (activeEnvironment === undefined) {
         <span>
           <app-icon name="eye-off"></app-icon>
-          <span>{{ 'NO_ENVIRONMENT_TEXT' | translate }}</span>
+          <span>{{ environments?.base?.title ?? ('NO_ENVIRONMENT_TEXT' | translate) }}</span>
         </span>
       }
     </li>
@@ -90,12 +90,7 @@
             nz-menu-item
             (click)="selectActiveEnvironmentChange.emit(undefined)"
             >
-            @if (environments?.base?.title) {
-              {{ environments.base.title }}
-            }
-            @else {
-              {{ 'NO_ENVIRONMENT_TEXT' | translate }}
-            }
+            {{ environments?.base?.title ?? ('NO_ENVIRONMENT_TEXT' | translate) }}
           </li>
           <li nz-menu-divider></li>
         }

--- a/packages/altair-app/src/app/modules/altair/store/environments/environments.reducer.ts
+++ b/packages/altair-app/src/app/modules/altair/store/environments/environments.reducer.ts
@@ -34,10 +34,18 @@ const getInitialSubEnvironmentState = (): EnvironmentState[] => {
   });
 };
 
+const getInitialActiveSubEnvironment = (): string | undefined => {
+  const {
+    initialData: { environments },
+  } = getAltairConfig();
+  return environments.activeSubEnvironment;
+};
+
 export const getInitialState = (): EnvironmentsState => {
   return {
     base: getInitialEnvironmentState(),
     subEnvironments: getInitialSubEnvironmentState(),
+    activeSubEnvironment: getInitialActiveSubEnvironment(),
   };
 };
 
@@ -57,11 +65,7 @@ export function environmentsReducer(
             title:
               action.payload.title ??
               `Environment ${state.subEnvironments.length + 1}`,
-            variablesJson: JSON.stringify(
-              action.payload.variables ?? {},
-              null,
-              2
-            ),
+            variablesJson: JSON.stringify(action.payload.variables ?? {}, null, 2),
           },
         ],
       };

--- a/packages/altair-core/src/config/options.ts
+++ b/packages/altair-core/src/config/options.ts
@@ -96,6 +96,7 @@ export interface AltairConfigOptions extends AltairWindowOptions {
    * Initial Environments to be added
    * @example
    * {
+   *   activeSubEnvironment: 'sub-1'
    *   base: {
    *     title: 'Environment',
    *     variables: {}

--- a/packages/altair-core/src/types/state/environments.interfaces.ts
+++ b/packages/altair-core/src/types/state/environments.interfaces.ts
@@ -7,6 +7,7 @@ export interface InitialEnvironmentState {
 }
 
 export interface IInitialEnvironments {
+  activeSubEnvironment?: string;
   base?: InitialEnvironmentState;
   subEnvironments?: InitialEnvironmentState[];
 }


### PR DESCRIPTION
### Fixes #
No issue

### Checks

- [X] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [x] Updated matching config options in altair-static

### Changes proposed in this pull request:
Header component checks whether title has been set in the configuration for the base environment and displays it otherwise default behaviour will be executed.

## Summary by Sourcery

Bug Fixes:
- Ensure the header component respects the title configuration for the base environment by displaying the configured title if set, otherwise defaulting to the previous behavior.