### PR TITLE
support flatpak

### DIFF
--- a/.github/workflows/_publish-electron.yml
+++ b/.github/workflows/_publish-electron.yml
@@ -99,6 +99,9 @@ jobs:
         run: |
           mkdir -p ~/private_keys/
           echo '${{ secrets.apple_api_key }}' > ~/private_keys/AuthKey_${{ secrets.apple_api_key_id }}.p8
+      - name: Install flatpak and flatpak-builder
+        run: sudo apt-get install -y flatpak flatpak-builder
+        if: startsWith(matrix.os, 'ubuntu')
       - name:
           Build/release Electron app
           # disable for macos not in master branch, because code signing is skipped in pull requests

--- a/.github/workflows/_publish-electron.yml
+++ b/.github/workflows/_publish-electron.yml
@@ -106,6 +106,8 @@ jobs:
         run: sudo apt-get install -y flatpak flatpak-builder elfutils
         if: startsWith(matrix.os, 'ubuntu')
       - name: Install flathub repo
+        # Need to install flatpak dependencies manually
+        # https://github.com/electron/forge/issues/2662#issuecomment-1003900006
         run: |
           sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak update --appstream
           sudo flatpak install org.freedesktop.Sdk/x86_64/23.08 -y
@@ -142,6 +144,10 @@ jobs:
       # chocolatey
       - name: Read VERSION file
         id: getversion
+        run: |
+          echo "::set-output name=version::$(cat VERSION)"
+      - name: Read VERSION file
+        id: getversionv2
         run: |
           echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
       - name: Add mask

--- a/.github/workflows/_publish-electron.yml
+++ b/.github/workflows/_publish-electron.yml
@@ -107,7 +107,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
       - name: Install flathub repo
         run: |
-          sudo flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak update --appstream
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak update --appstream
           sudo flatpak install org.freedesktop.Sdk/x86_64/23.08 -y
           sudo flatpak install org.freedesktop.Platform/x86_64/23.08 -y
           sudo flatpak install org.electronjs.Electron2.BaseApp/x86_64/23.08 -y

--- a/.github/workflows/_publish-electron.yml
+++ b/.github/workflows/_publish-electron.yml
@@ -107,7 +107,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
       - name: Install flathub repo
         run: |
-          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak update --appstream
+          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak update --appstream
           sudo flatpak install org.freedesktop.Sdk/x86_64/23.08 -y
           sudo flatpak install org.freedesktop.Platform/x86_64/23.08 -y
           sudo flatpak install org.electronjs.Electron2.BaseApp/x86_64/23.08 -y

--- a/.github/workflows/_publish-electron.yml
+++ b/.github/workflows/_publish-electron.yml
@@ -126,6 +126,7 @@ jobs:
           APPLEIDPASS: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
+          DEBUG: '@malept/flatpak-bundler'
 
       # chocolatey
       - name: Read VERSION file

--- a/.github/workflows/_publish-electron.yml
+++ b/.github/workflows/_publish-electron.yml
@@ -142,7 +142,8 @@ jobs:
       # chocolatey
       - name: Read VERSION file
         id: getversion
-        run: echo "::set-output name=version::$(cat VERSION)"
+        run: |
+          echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
       - name: Add mask
         run: |
           echo "::add-mask::${{ secrets.CHOCOLATEY_API_KEY }}"

--- a/.github/workflows/_publish-electron.yml
+++ b/.github/workflows/_publish-electron.yml
@@ -88,20 +88,28 @@ jobs:
       - run: pnpm i --frozen-lockfile
       # Create deploy ready source files for electron
       - run: pnpm deploy --filter=altair out/elx-files
+
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
         if: startsWith(matrix.os, 'ubuntu')
         env:
           SNAPCRAFT_TOKEN: ${{ secrets.SNAPCRAFT_TOKEN }}
+
       - name: Prepare for app notarization
         if: startsWith(matrix.os, 'macos')
         # Import Apple API key for app notarization on macOS
         run: |
           mkdir -p ~/private_keys/
           echo '${{ secrets.apple_api_key }}' > ~/private_keys/AuthKey_${{ secrets.apple_api_key_id }}.p8
+
       - name: Install flatpak and flatpak-builder
         run: sudo apt-get install -y flatpak flatpak-builder
         if: startsWith(matrix.os, 'ubuntu')
+      - name: Install flathub repo
+        run: |
+          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak update --appstream
+        if: matrix.os == 'ubuntu-latest'
+
       - name:
           Build/release Electron app
           # disable for macos not in master branch, because code signing is skipped in pull requests

--- a/.github/workflows/_publish-electron.yml
+++ b/.github/workflows/_publish-electron.yml
@@ -103,12 +103,15 @@ jobs:
           echo '${{ secrets.apple_api_key }}' > ~/private_keys/AuthKey_${{ secrets.apple_api_key_id }}.p8
 
       - name: Install flatpak and flatpak-builder
-        run: sudo apt-get install -y flatpak flatpak-builder
+        run: sudo apt-get install -y flatpak flatpak-builder elfutils
         if: startsWith(matrix.os, 'ubuntu')
       - name: Install flathub repo
         run: |
-          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak update --appstream
-        if: matrix.os == 'ubuntu-latest'
+          sudo flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && flatpak update --appstream
+          sudo flatpak install org.freedesktop.Sdk/x86_64/23.08 -y
+          sudo flatpak install org.freedesktop.Platform/x86_64/23.08 -y
+          sudo flatpak install org.electronjs.Electron2.BaseApp/x86_64/23.08 -y
+        if: startsWith(matrix.os, 'ubuntu')
 
       - name:
           Build/release Electron app

--- a/packages/altair-electron/electron-builder.yml
+++ b/packages/altair-electron/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.xkoji.altair
 productName: Altair GraphQL Client
-electronVersion: 26.2.2
+electronVersion: 33.2.1
 directories:
   buildResources: resources
   output: out
@@ -24,6 +24,7 @@ mac:
         - arm64
   icon: resources/mac_icon.icns
   hardenedRuntime: true
+  darkModeSupport: true
   entitlements: resources/entitlements.mac.plist
   entitlementsInherit: resources/entitlements.mac.plist
   strictVerify: false
@@ -33,10 +34,16 @@ dmg:
 linux:
   artifactName: ${name}_${version}_${arch}_linux.${ext}
   icon: resources/icons
+  category: Development
+  maintainer: info@altairgraphql.dev
   target:
-    - AppImage
+    - target: AppImage
+      arch:
+        - x64
+        - arm64
     - deb
     - snap
+    - flatpak
 appImage:
   category: Development
 snap:
@@ -50,6 +57,10 @@ snap:
       bind: $SNAP/usr/share/libdrm
 win:
   artifactName: ${name}_${version}_${arch}_win.${ext}
+flatpak:
+  artifactName: ${name}_${version}_${arch}_flatpak.${ext}
+  runtimeVersion: '24.08'
+  baseVersion: '24.08'
 electronCompile: false
 protocols:
   name: Altair GraphQL Client

--- a/packages/altair-electron/electron-builder.yml
+++ b/packages/altair-electron/electron-builder.yml
@@ -59,6 +59,8 @@ win:
   artifactName: ${name}_${version}_${arch}_win.${ext}
 flatpak:
   artifactName: ${name}_${version}_${arch}_flatpak.${ext}
+  runtime: org.freedesktop.Platform
+  runtimeVersion: '23.08'
 electronCompile: false
 protocols:
   name: Altair GraphQL Client

--- a/packages/altair-electron/electron-builder.yml
+++ b/packages/altair-electron/electron-builder.yml
@@ -61,6 +61,7 @@ flatpak:
   artifactName: ${name}_${version}_${arch}_flatpak.${ext}
   runtime: org.freedesktop.Platform
   runtimeVersion: '23.08'
+  baseVersion: '23.08'
 electronCompile: false
 protocols:
   name: Altair GraphQL Client

--- a/packages/altair-electron/electron-builder.yml
+++ b/packages/altair-electron/electron-builder.yml
@@ -59,8 +59,6 @@ win:
   artifactName: ${name}_${version}_${arch}_win.${ext}
 flatpak:
   artifactName: ${name}_${version}_${arch}_flatpak.${ext}
-  runtimeVersion: '24.08'
-  baseVersion: '24.08'
 electronCompile: false
 protocols:
   name: Altair GraphQL Client


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
Partially resolves #649 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Upgrade Electron to version 33.2.1 and add support for Flatpak builds.

Build:
- Add Flatpak as a build target for Linux.

CI:
- Install flatpak and flatpak-builder dependencies in the CI workflow.