### PR TITLE
Update `development.md`, fix incorrect local development steps

### DIFF
--- a/.github/development.md
+++ b/.github/development.md
@@ -1,19 +1,22 @@
 ## Development
 
-Run `yarn` from the root of the repository to install dependencies.
-Run `yarn start:app` to start the local dev server of the web app. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Run `pnpm install` from the root of the repository to install dependencies.
+
+Run `pnpm bootstrap` to build local projects, this is necessary to compile JS into TS and make sure types imported from other projects are accessible
+
+Run `pnpm start:app` to start the local dev server of the web app. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
 ### Build
 
-Run `yarn build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `-prod` flag for a production build.
+Run `pnpm build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `-prod` flag for a production build.
 
 ### Generate chrome extension files
 
-Run `yarn build-ext` to build the chrome extension files. The extension files will be stored in the `chrome-extension/` directory.
+Run `pnpm build-ext` to build the chrome extension files. The extension files will be stored in the `chrome-extension/` directory.
 
 ### Generate electron app
 
-Run `yarn build-electron` to build the electron apps. The apps will be stored in the `electron-builds/` directory.
+Run `pnpm build-electron` to build the electron apps. The apps will be stored in the `electron-builds/` directory.
 
 ### Updating docs
 
@@ -21,4 +24,4 @@ Run `bundle exec jekyll serve`.
 
 ### Running tests
 
-Run `yarn test` to execute tests across all packages.
+Run `pnpm test` to execute tests across all packages.


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Update local development instructions to use `pnpm` instead of `yarn` for managing dependencies, building the project, generating Chrome extension files, building Electron apps, and running tests.  Add a `pnpm bootstrap` step to build local projects and compile JS into TS.

Enhancements:
- Switch from `yarn` to `pnpm` for package management.

Documentation:
- Update the local development documentation to reflect the switch from `yarn` to `pnpm`.