### PR TITLE
updated docker push github action

### DIFF
--- a/.github/workflows/_push-docker.yml
+++ b/.github/workflows/_push-docker.yml
@@ -7,6 +7,11 @@ on:
         description: 'Whether to push the Docker image'
         required: true
         type: boolean
+      release:
+        description: 'Whether to push as latest release'
+        required: false
+        default: false
+        type: boolean
       version:
         description: 'Version to use'
         required: false
@@ -18,6 +23,11 @@ on:
         description: 'Whether to push the Docker image'
         required: true
         type: boolean
+      release:
+        description: 'Whether to push as latest release'
+        required: false
+        default: false
+        type: boolean
       version:
         description: 'Version to use'
         required: false
@@ -25,6 +35,14 @@ on:
         type: string
 
 jobs:
+  docker-vars:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ inputs.version || format('{0}-{1}', github.sha, env.COMMIT_TIMESTAMP) }}
+    steps:
+      - name: Get Git commit timestamps
+        run: echo "COMMIT_TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+      - run: echo "Exposing env vars"
   docker:
     runs-on: ubuntu-latest
     steps:
@@ -64,7 +82,7 @@ jobs:
           load: true
           push: ${{ inputs.push }}
           tags: |
-            ${{ inputs.push && format('{0}/altairgraphqlapi:latest', secrets.DOCKERHUB_USERNAME) || '' }}
+            ${{ inputs.push && inputs.release && format('{0}/altairgraphqlapi:latest', secrets.DOCKERHUB_USERNAME) || '' }}
             ${{ inputs.push && inputs.version && format('{0}/altairgraphqlapi:{1}', secrets.DOCKERHUB_USERNAME, inputs.version) || '' }}
-            ${{ inputs.push && format('ghcr.io/{0}/altairgraphqlapi:latest', github.repository_owner) || '' }}
+            ${{ inputs.push && inputs.release && format('ghcr.io/{0}/altairgraphqlapi:latest', github.repository_owner) || '' }}
             ${{ inputs.push && inputs.version && format('ghcr.io/{0}/altairgraphqlapi:{1}', github.repository_owner, inputs.version) || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/_push-docker.yml
     with:
       push: true
+      release: true
       version: ${{ needs.prepare-release.outputs.release-tag }}
     secrets: inherit
 


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Update the push-docker GitHub Action to allow pushing Docker images as the latest release and to generate dynamic versions.

CI:
- Add a 'release' input to the push-docker workflow to control whether to push the Docker image as the latest release.
- Generate a dynamic version based on the Git SHA and commit timestamp if no version is provided as input.