### PR TITLE
support graphql extension for loading schema

### DIFF
--- a/packages/altair-app/src/app/modules/altair/effects/query.effect.ts
+++ b/packages/altair-app/src/app/modules/altair/effects/query.effect.ts
@@ -531,7 +531,7 @@ export class QueryEffects {
       return this.actions$.pipe(
         ofType(gqlSchemaActions.LOAD_SDL_SCHEMA),
         mergeMap((data: gqlSchemaActions.LoadSDLSchemaAction) => {
-          openFile({ accept: '.gql' }).then((sdlData: string) => {
+          openFile({ accept: ['.gql', '.graphql'] }).then((sdlData: string) => {
             try {
               const schema = this.gqlService.sdlToSchema(sdlData);
               if (schema) {


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
Closes #2783 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Allow loading GraphQL schema from files with the `.graphql` extension.