### PR TITLE
allow exporting remote collection

### DIFF
--- a/packages/altair-app/src/app/modules/altair/services/api/api.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/api/api.service.ts
@@ -146,12 +146,17 @@ export class ApiService {
   async getCollection(
     collectionServerId: string
   ): Promise<IQueryCollection | undefined> {
-    const res = await apiClient.getCollection(collectionServerId);
-    if (!res) {
+    try {
+      const res = await apiClient.getCollection(collectionServerId);
+      if (!res) {
+        return;
+      }
+
+      return serverCollectionToLocalCollection(res);
+    } catch (e) {
+      console.error(e);
       return;
     }
-
-    return serverCollectionToLocalCollection(res);
   }
 
   async getCollections(): Promise<IQueryCollection[]> {

--- a/packages/altair-app/src/app/modules/altair/services/api/api.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/api/api.service.ts
@@ -154,6 +154,7 @@ export class ApiService {
 
       return serverCollectionToLocalCollection(res);
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.error(e);
       return;
     }

--- a/packages/altair-app/src/app/modules/altair/services/query-collection/query-collection.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/query-collection/query-collection.service.ts
@@ -117,11 +117,19 @@ export class QueryCollectionService {
     }
 
     collection.queries = collection.queries.map((query) => {
-      return { ...query, id: uuid(), created_at: now, updated_at: now };
+      return {
+        ...query,
+        storageType: 'local',
+        id: uuid(),
+        created_at: now,
+        updated_at: now,
+      };
     });
 
     return this.storage.queryCollections.add({
       ...collection,
+      storageType: 'local',
+      workspaceId: WORKSPACES.LOCAL,
       id: collectionId ?? uuid(),
       parentPath,
       created_at: now,
@@ -694,7 +702,7 @@ export class QueryCollectionService {
   }
 
   async getCollectionTreeByCollectionId(collectionId: CollectionID) {
-    const collection = await this.getLocalCollectionByID(collectionId);
+    const collection = await this.getCollectionByID(collectionId);
     if (!collection) {
       throw new Error('Collection not found!');
     }

--- a/packages/altair-app/src/scss/_ant-overrides.scss
+++ b/packages/altair-app/src/scss/_ant-overrides.scss
@@ -40,8 +40,29 @@
 .ant-modal-confirm-body .ant-modal-confirm-content {
   color: var(--theme-font-color);
 }
+.ant-btn {
+  // background: var(--theme-off-bg-color);
+  // color: var(--theme-font-color);
+  // border-color: var(--theme-border-color);
+  border-radius: 4px;
+  // font-size: fontsize(12);
+  // padding: 0.5rem 1rem;
+}
 .ant-btn-primary {
   background-color: var(--primary-color);
+  border-color: var(--primary-color);
+  color: var(--theme-font-color);
+}
+.ant-btn-primary:focus,
+.ant-btn-primary:hover {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+  color: var(--theme-font-color);
+}
+.ant-btn:focus,
+.ant-btn:hover {
+  color: var(--primary-color);
+  border-color: var(--primary-color);
 }
 
 .anticon {


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
#2792 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Add support for exporting and managing remote query collections in Altair

Bug Fixes:
- Fix collection import process to correctly set storage type and workspace for imported collections

Enhancements:
- Improve collection management by adding support for remote collection storage types
- Enhance error handling when retrieving collections
- Update collection retrieval methods to handle remote and local collections

Chores:
- Update styling for Ant Design buttons to improve visual consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Local collections and their queries now include metadata indicating local storage.
  - Collections can be retrieved whether stored locally or remotely.

- **Bug Fixes**
  - Enhanced error handling and logging during collection retrieval to prevent unhandled errors.

- **Style**
  - Refined button styles for consistent appearance and improved theming throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->