### PR TITLE
disable cache for electron popups

### DIFF
--- a/packages/altair-electron/src/app/index.ts
+++ b/packages/altair-electron/src/app/index.ts
@@ -196,7 +196,17 @@ export class ElectronApp {
 
           // Allow popups to be opened in the app
           if (details.features.includes('popup')) {
-            return { action: 'allow' };
+            // session cache should be cleared for popup windows
+            return {
+              action: 'allow',
+              overrideBrowserWindowOptions: {
+                webPreferences: {
+                  session: session.fromPartition('persist:popup', {
+                    cache: false,
+                  }),
+                },
+              },
+            };
           }
           shell.openExternal(url.href);
         } catch (err) {

--- a/packages/altair-electron/src/app/index.ts
+++ b/packages/altair-electron/src/app/index.ts
@@ -201,9 +201,7 @@ export class ElectronApp {
               action: 'allow',
               overrideBrowserWindowOptions: {
                 webPreferences: {
-                  session: session.fromPartition('persist:popup', {
-                    cache: false,
-                  }),
+                  partition: 'popup',
                 },
               },
             };


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
#2820 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Enhancements:
- Configure popup windows to use a dedicated session with caching disabled via overrideBrowserWindowOptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Popup windows now use a separate session with caching disabled, providing improved privacy and session management for popups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->