### PR TITLE
return undefined instead of throwing an error if invalid plugin

### DIFF
--- a/packages/altair-app/src/app/modules/altair/services/plugin/plugin-registry.service.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/services/plugin/plugin-registry.service.spec.ts
@@ -59,14 +59,14 @@ describe('PluginRegistryService', () => {
   });
 
   describe('.getPluginInfoFromString()', () => {
-    it('return null for empty string', () => {
+    it('return undefined for empty string', () => {
       const service: PluginRegistryService = TestBed.get(PluginRegistryService);
       expect(service.getPluginInfoFromString('')).toBeUndefined();
     });
 
-    it('should throw error if plugin name does not follow specification', () => {
+    it('return undefined if plugin name does not follow specification', () => {
       const service: PluginRegistryService = TestBed.get(PluginRegistryService);
-      expect(() => service.getPluginInfoFromString('plugin-name')).toThrow();
+      expect(service.getPluginInfoFromString('plugin-name')).toBeUndefined();
     });
 
     it('return version as latest, if version is not specified', () => {
@@ -83,9 +83,7 @@ describe('PluginRegistryService', () => {
     it('return pluginSource as npm, if pluginSource is not specified', () => {
       const service: PluginRegistryService = TestBed.get(PluginRegistryService);
       expect(
-        service.getPluginInfoFromString(
-          'altair-graphql-plugin-plugin-name@0.0.1'
-        )
+        service.getPluginInfoFromString('altair-graphql-plugin-plugin-name@0.0.1')
       ).toEqual({
         name: 'altair-graphql-plugin-plugin-name',
         version: '0.0.1',

--- a/packages/altair-app/src/app/modules/altair/services/plugin/plugin-registry.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/plugin/plugin-registry.service.ts
@@ -157,7 +157,8 @@ export class PluginRegistryService {
       ] = matches;
       if (pluginName && pluginVersion) {
         if (!pluginName.startsWith(PLUGIN_NAME_PREFIX)) {
-          throw new Error(`Plugin name must start with ${PLUGIN_NAME_PREFIX}`);
+          debug.error(`Plugin name must start with ${PLUGIN_NAME_PREFIX}`);
+          return;
         }
         return {
           name: pluginName,


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
#2815 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->