### PR TITLE
Add search collections feature

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/query-collection-item/query-collection-item.component.ts
+++ b/packages/altair-app/src/app/modules/altair/components/query-collection-item/query-collection-item.component.ts
@@ -4,6 +4,8 @@ import {
   Output,
   EventEmitter,
   ChangeDetectionStrategy,
+  OnChanges,
+  SimpleChanges,
 } from '@angular/core';
 import {
   IQuery,
@@ -20,10 +22,11 @@ import { memoize } from '../../utils/memoize';
   styleUrls: ['./query-collection-item.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class QueryCollectionItemComponent {
+export class QueryCollectionItemComponent implements OnChanges {
   @Input() collectionTree?: IQueryCollectionTree;
   @Input() loggedIn = false;
   @Input() queriesSortBy: SortByOptions = 'newest';
+  @Input() expanded = true;
 
   @Output() selectQueryChange = new EventEmitter();
   @Output() deleteQueryChange: EventEmitter<{
@@ -47,6 +50,12 @@ export class QueryCollectionItemComponent {
   showContent = true;
 
   constructor(private modal: NzModalService) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['expanded'] && changes['expanded'].currentValue !== undefined) {
+      this.showContent = changes['expanded'].currentValue;
+    }
+  }
 
   getQueryCount(collection: IQueryCollectionTree) {
     return collection.queries && collection.queries.length;

--- a/packages/altair-app/src/app/modules/altair/components/query-collections/query-collections.component.html
+++ b/packages/altair-app/src/app/modules/altair/components/query-collections/query-collections.component.html
@@ -33,28 +33,29 @@
           </button>
         }
         <div class="query-collections__actions--right">
-          <button
-            nz-dropdown
-            nzTrigger="click"
-            [nzDropdownMenu]="docViewerMenu"
-            type="button"
-            class="btn btn--small"
-          >
-            @switch (sortBy) {
-              @case ('a-z') {
-                {{ 'SORT_BY_A_Z' | translate }}
-              }
-              @case ('z-a') {
-                {{ 'SORT_BY_Z_A' | translate }}
-              }
-              @case ('newest') {
-                {{ 'SORT_BY_NEWEST' | translate }}
-              }
-              @case ('oldest') {
-                {{ 'SORT_BY_OLDEST' | translate }}
-              }
-            }
-          </button>
+          <div class="collections-actions-row">
+            <input
+              type="text"
+              class="input input--small"
+              placeholder="{{ 'SEARCH_COLLECTIONS_PLACEHOLDER' | translate }}"
+              [value]="searchTerm$ | async"
+              (input)="setSearchTerm($any($event.target).value)"
+            />
+            <button
+              nz-dropdown
+              nzTrigger="click"
+              [nzDropdownMenu]="docViewerMenu"
+              type="button"
+              class="btn btn--small"
+            >
+              <span [ngSwitch]="sortBy">
+                <span *ngSwitchCase="'a-z'">{{ 'SORT_BY_A_Z' | translate }}</span>
+                <span *ngSwitchCase="'z-a'">{{ 'SORT_BY_Z_A' | translate }}</span>
+                <span *ngSwitchCase="'newest'">{{ 'SORT_BY_NEWEST' | translate }}</span>
+                <span *ngSwitchCase="'oldest'">{{ 'SORT_BY_OLDEST' | translate }}</span>
+              </span>
+            </button>
+          </div>
           <nz-dropdown-menu #docViewerMenu="nzDropdownMenu">
             <ul nz-menu>
               <li nz-menu-item (click)="sortCollectionsChange.emit('a-z')">
@@ -120,6 +121,7 @@
             [collectionTree]="collectionTree"
             [loggedIn]="loggedIn"
             [queriesSortBy]="queriesSortBy"
+            [expanded]="expandedMap[collectionTree.id] || false"
             (selectQueryChange)="selectQueryChange.emit($event)"
             (deleteQueryChange)="deleteQueryChange.emit($event)"
             (deleteCollectionChange)="deleteCollectionChange.emit($event)"

--- a/packages/altair-app/src/app/modules/altair/components/query-collections/query-collections.component.scss
+++ b/packages/altair-app/src/app/modules/altair/components/query-collections/query-collections.component.scss
@@ -1,0 +1,10 @@
+.collections-actions-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.input.input--small {
+  width: 81px;
+  min-width: 0;
+}

--- a/packages/altair-app/src/assets/i18n/en-US.json
+++ b/packages/altair-app/src/assets/i18n/en-US.json
@@ -146,6 +146,7 @@
   "COLLECTION_SYNC_TEXT": "Refresh",
   "COLLECTIONS_WORKSPACES_SELECT_ALL": "All workspaces",
   "COLLECTIONS_WORKSPACES_FILTER": "Filter workspaces",
+  "SEARCH_COLLECTIONS_PLACEHOLDER": "Search",
   "QUERY_REVISIONS_TEXT": "Query Revisions",
   "QUERY_REVISIONS_SUB_TEXT": "You can view and restore previous versions of this query",
   "EDIT_COLLECTION_TITLE_TEXT": "Edit Collection",


### PR DESCRIPTION
### Fixes #
PR adds functionality to search for query within all collections and their subcollections.

### Changes proposed in this pull request:
In the collections view, add a new text field `Search`. This field will accept text and filter for any queries matching this text by name in all collections. 


### Demo 
https://github.com/user-attachments/assets/7f5d354d-4e3a-4a37-bb5d-9d9e5b90e873

