### PR TITLE
add options to disable banners

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/banner-container/banner-container.component.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/components/banner-container/banner-container.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BannerContainerComponent } from './banner-container.component';
+import { MockProvider } from 'ng-mocks';
+import { Store } from '@ngrx/store';
 
 describe('BannerContainerComponent', () => {
   let component: BannerContainerComponent;
@@ -9,6 +11,7 @@ describe('BannerContainerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [BannerContainerComponent],
+      providers: [MockProvider(Store)],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BannerContainerComponent);

--- a/packages/altair-core/src/types/state/settings.interfaces.ts
+++ b/packages/altair-core/src/types/state/settings.interfaces.ts
@@ -102,6 +102,11 @@ export interface SettingsState {
   'alert.disableWarnings'?: boolean;
 
   /**
+   * Disable banners
+   */
+  'banners.disable'?: boolean;
+
+  /**
    * Number of items allowed in history pane
    */
   historyDepth?: number;


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
#2837 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Introduce a new setting to disable banners and update the banner container to hide all banners when this setting is enabled.

New Features:
- Add a 'banners.disable' setting to global state to allow disabling all banners.

Enhancements:
- Update BannerContainerComponent to respect the 'banners.disable' flag and suppress banner output when enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to disable banners in the application. When enabled, banners will no longer be displayed.
* **Bug Fixes**
  * Improved banner display logic to reactively update based on the new disable setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->