### PR TITLE
fix: prevent canceling one subscription from canceling all active subscriptions

### DIFF
--- a/packages/altair-app/src/app/modules/altair/effects/query.effect.ts
+++ b/packages/altair-app/src/app/modules/altair/effects/query.effect.ts
@@ -359,7 +359,12 @@ export class QueryEffects {
                     return result;
                   }),
                   takeUntil(
-                    this.actions$.pipe(ofType(queryActions.CANCEL_QUERY_REQUEST))
+                    this.actions$.pipe(
+                      ofType(queryActions.CANCEL_QUERY_REQUEST),
+                      filter((action: queryActions.CancelQueryRequestAction) => 
+                        action.windowId === response.windowId
+                      )
+                    )
                   ),
                   catchError((error) => {
                     let output =


### PR DESCRIPTION
## Problem
When multiple GraphQL subscriptions are running in different windows, canceling one subscription incorrectly cancels **all** active subscriptions across all windows.

## Root Cause
The `takeUntil` operator in the `sendQueryRequest$` effect was listening for **any** `CANCEL_QUERY_REQUEST` action globally, instead of filtering for the specific window ID. This caused all ongoing requests to be terminated when any single request was canceled.

## Changes
- **Modified**: `packages/altair-app/src/app/modules/altair/effects/query.effect.ts`
- **Fixed**: Added window-specific filtering to the `takeUntil` operator on lines 361-367
- **Impact**: Each subscription can now be canceled independently without affecting others

## Technical Details
```typescript
// Before (BUGGY - global listener)
takeUntil(
  this.actions$.pipe(ofType(queryActions.CANCEL_QUERY_REQUEST))
),

// After (FIXED - window-specific listener)  
takeUntil(
  this.actions$.pipe(
    ofType(queryActions.CANCEL_QUERY_REQUEST),
    filter((action: queryActions.CancelQueryRequestAction) => 
      action.windowId === response.windowId
    )
  )
),
```

## Testing
- ✅ **Manual Testing**: Start multiple subscriptions, cancel one → only that subscription stops
- ❌ **Unit Tests**: No existing test pattern for this effect (minimal test coverage in `query.effect.spec.ts`)

## Affected Components
- **Only affects**: Main query/subscription requests (`sendQueryRequest$` effect)
- **Does not affect**: Introspection queries, utility operations (prettify, compress, etc.)

This fix resolves the cross-window cancellation issue while maintaining backward compatibility and following the project's established patterns.

## Summary by Sourcery

Bug Fixes:
- Scope CANCEL_QUERY_REQUEST handling to matching windowId so that canceling one subscription no longer cancels all others.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canceling an in-flight GraphQL request now only affects the corresponding window, preventing unintended cancellations across multiple windows.
  * Improves reliability when running requests in parallel across different windows.
  * Enhances multi-window workflows by ensuring each window’s requests are independently managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->