### PR TITLE
Fix: replace Array.map with for..of loop to comply with Sonar rule S2201

### DIFF
--- a/packages/altair-app/src/app/modules/altair/store/async-storage-sync.ts
+++ b/packages/altair-app/src/app/modules/altair/store/async-storage-sync.ts
@@ -141,7 +141,7 @@ const getSyncOperations = (
     });
   });
 
-  Object.keys(normalizedNewState).map((key) => {
+  for (const key of Object.keys(normalizedNewState)) {
     // Add operation only if value is changed
     if (normalizedNewState[key] !== normalizedOldState[key]) {
       const valueToStore = prepareValueToStore(key, normalizedNewState[key]);
@@ -155,7 +155,7 @@ const getSyncOperations = (
         value: serializeValue(valueToStore),
       });
     }
-  });
+  }
 
   return ops;
 };


### PR DESCRIPTION
(Sonar S2201)

### Fixes #
Bug fix / Code quality improvement.
Replaced Object.keys(...).map with a for..of loop since the return value from map was unused. 
This resolves Sonar rule S2201 ("Return values from functions should not be ignored") and 
makes the iteration intent clearer while avoiding unnecessary array creation. No functional 
changes were introduced.

### Checks

- [x] Ran `yarn test-build`
- [x] Updated relevant documentations
- [x] Updated matching config options in altair-static

## Changes proposed in this pull request:
### What is the current behavior?
The code was using Object.keys(...).map to iterate over keys,
but the return value of map was not used. This triggered
SonarQube rule TypeScript:S2201 ("Return values from functions
should not be ignored").

### What is the new behavior?
Replaced the .map() call with a for..of loop, since the iteration
was intended only for side effects (ops.push). This makes the
intention clearer, avoids unnecessary array creation, and resolves
the Sonar violation.

### Why is this change needed?
- Ensures compliance with SonarQube rule S2201
- Improves code readability by using iteration explicitly
- Avoids confusion about unused return values

### Other information
No functional changes. Only a refactor to improve clarity and
maintainability.

## Summary by Sourcery

Refactor side-effect iteration in async-storage-sync to use a for..of loop instead of Object.keys().map to comply with Sonar rule S2201 and improve code clarity

Bug Fixes:
- Resolve Sonar S2201 by eliminating unused return values from Array.map

Enhancements:
- Replace Object.keys(...).map with a for..of loop in getSyncOperations to avoid unnecessary array creation and clarify intent