### PR TITLE
test(account-dialog): add unit tests and 100% coverage for AccountDialogComponent

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/account-dialog/account-dialog.component.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/components/account-dialog/account-dialog.component.spec.ts
@@ -2,10 +2,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, expect, it } from '@jest/globals';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import { mount, NgxTestWrapper } from '../../../../../testing';
+import { mock, mount, NgxTestWrapper } from '../../../../../testing';
 import { SharedModule } from '../../modules/shared/shared.module';
 
 import { AccountDialogComponent } from './account-dialog.component';
+import { apiClient } from '../../services/api/api.service';
+import * as externalUtils from '../../utils';
 
 describe('AccountDialogComponent', () => {
   let wrapper: NgxTestWrapper<AccountDialogComponent>;
@@ -25,8 +27,18 @@ describe('AccountDialogComponent', () => {
     fixture.detectChanges();
   });
 
+  beforeEach(() => jest.clearAllMocks());
+
   it('should create', () => {
     expect(wrapper.component.nativeElement).toMatchSnapshot();
+  });
+
+  it ('should have default showDialog as true', () => {
+    expect(component.showDialog).toBe(true);
+  });
+
+  it('should have undefined account by default', () => {
+    expect(component.account).toBeUndefined();
   });
 
   it('should emit "handleLoginChange" when login is clicked', () => {
@@ -35,5 +47,58 @@ describe('AccountDialogComponent', () => {
     login.emit('click');
 
     expect(wrapper.emitted('handleLoginChange')).toBeTruthy();
+  });
+
+  it('should emit handleLoginChange on submitLogin', () => {
+    jest.spyOn(component.handleLoginChange, 'emit');
+    component.submitLogin();
+    expect(component.handleLoginChange.emit).toHaveBeenCalled();
+  });
+
+  it ('should open billing page with correct URL', async () => {
+    const mockUrl = 'https://billing.example.com';
+    jest.spyOn(apiClient, 'getBillingUrl').mockResolvedValue({ url: mockUrl });
+    const mockEvent = new MouseEvent('click');
+    const externalSpy = jest.spyOn(externalUtils, 'externalLink').mockImplementation(() => {});
+
+    await component.openBillingPage(mockEvent);
+
+    expect(apiClient.getBillingUrl).toHaveBeenCalledWith();
+    expect(externalSpy).toHaveBeenCalledWith(mockUrl, mockEvent);
+  });
+
+  it ('should call getUpgradeProUrl and open external link', async () => {
+    const mockUrl = 'https://upgrade.example.com';
+    jest.spyOn(apiClient, 'getUpgradeProUrl').mockResolvedValue({ url: mockUrl });
+    const mockEvent = new MouseEvent('click');
+    const externalSpy = jest.spyOn(externalUtils, 'externalLink').mockImplementation(() => {});
+
+    await component.openUpgradeProUrl(mockEvent);
+
+    expect(apiClient.getUpgradeProUrl).toHaveBeenCalledWith();
+    expect(externalSpy).toHaveBeenCalledWith(mockUrl, mockEvent);
+  });
+
+  it ('should call buyCredits and open external link if url exists', async () => {
+    const mockUrl = 'https://credits.example.com';
+    jest.spyOn(apiClient, 'buyCredits').mockResolvedValue({ url: mockUrl });
+    const mockEvent = new MouseEvent('click');
+    const externalSpy = jest.spyOn(externalUtils, 'externalLink').mockImplementation(() => {});
+
+    await component.buyCredits(mockEvent);
+
+    expect(apiClient.buyCredits).toHaveBeenCalledWith();
+    expect(externalSpy).toHaveBeenCalledWith(mockUrl, mockEvent);
+  });
+
+  it('should not call externalLink if buyCredits returns no url', async () => {
+    jest.spyOn(apiClient, 'buyCredits').mockResolvedValue({ url: '' });
+    const mockEvent = new MouseEvent('click');
+    const externalSpy = jest.spyOn(externalUtils, 'externalLink').mockImplementation(() => {});
+
+    await component.buyCredits(mockEvent);
+
+    expect(apiClient.buyCredits).toHaveBeenCalledWith();
+    expect(externalSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Fixes
This PR helps fix issue #1717  by adding comprehensive unit tests for AccountDialogComponent (component + template).

## Files changed
- packages/altair-app/src/app/modules/altair/components/account-dialog/account-dialog.component.spec.ts

## Coverage
The tests provide **100%** coverage...

## Summary by Sourcery

Add comprehensive unit tests for AccountDialogComponent to achieve 100% coverage, verifying component rendering, default state, event emissions, and external link behavior.

Tests:
- Add snapshot test for component rendering
- Verify default showDialog and account initial values
- Test handleLoginChange emission on login click and via submitLogin
- Test openBillingPage, openUpgradeProUrl, and buyCredits methods to call API and externalLink correctly, including handling missing URL case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for the account dialog, validating default visibility and account state.
  * Added tests for login submission flow and event emission.
  * Verified external link handling for billing and upgrade actions.
  * Covered credit purchase behavior, including both successful URL returns and empty URL scenarios.
  * Introduced setup to reset test mocks between runs for reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->