### PR TITLE
cache iframe loaded state to allow subsequent message sending

### DIFF
--- a/packages/altair-app/src/app/modules/altair/services/pre-request/evaluator-client.factory.ts
+++ b/packages/altair-app/src/app/modules/altair/services/pre-request/evaluator-client.factory.ts
@@ -16,6 +16,12 @@ export class EvaluatorFrameClient extends ScriptEvaluatorClient {
     (e: MessageEvent<ScriptEventData<ScriptEvent>>) => void
   > = [];
 
+  private iframeLoadedPromise = new Promise<void>((resolve) => {
+    this.iframe.addEventListener('load', () => {
+      resolve();
+    });
+  });
+
   constructor(private sandboxUrl: string) {
     super();
   }
@@ -55,10 +61,9 @@ export class EvaluatorFrameClient extends ScriptEvaluatorClient {
     // FIXME: we shouldn't use any here
     this.messageListeners.push(listener as any);
   }
-  send(type: string, payload: any): void {
-    this.iframe.addEventListener('load', () => {
-      this.iframe.contentWindow?.postMessage({ type, payload }, this.sandboxUrl);
-    });
+  async send(type: string, payload: any): Promise<void> {
+    await this.iframeLoadedPromise;
+    this.iframe.contentWindow?.postMessage({ type, payload }, this.sandboxUrl);
   }
   onError(handler: (err: any) => void): void {
     this.iframe.addEventListener('error', handler);


### PR DESCRIPTION
Currently only the initialisation message is sent to the iframe and subsequent calls don't satisfy the `load` event so never gets sent.

### Fixes #
<!-- Mention the issues this PR addresses -->
#2908 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Ensure that messages sent to the sandbox iframe after initialization are delivered by caching its load state and awaiting it in the send method

Bug Fixes:
- Fix issue where only the initial postMessage was delivered to the iframe by caching the load event

Enhancements:
- Introduce an iframeLoadedPromise to replace per-call load event listeners and convert send() to an async method that awaits the iframe load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed intermittent issues where pre-request scripts could be skipped or fail if the embedded panel wasn’t fully loaded. Communication now waits until the panel is ready, ensuring consistent execution and fewer errors.
- Refactor
  - Streamlined readiness handling for the embedded frame to use a single, reusable check, reducing event listener overhead and race conditions for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->