### PR TITLE
Add deployment badge for Hostinger

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Read more [here](.github/development.md).
 
 The docker image can be built from the [Dockerfile](./Dockerfile) at the root of the repo.
 
+#### Hostinger
+
+[![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/vps/docker-hosting?compose_url=docker-compose-url)
+
 #### Digitalocean
 
 [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/altair-graphql/altair/tree/master&refcode=345176f96acb)


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Documentation:
- Add a Hostinger section with a deploy badge linking to Hostinger VPS Docker hosting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Hostinger deployment option documentation under deployment guides, providing users with setup instructions and resources for deploying via Hostinger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->