### PR TITLE
fix: prevent prototype pollution in setByDotNotation

### DIFF
--- a/packages/altair-core/src/utils/dot-notation.spec.ts
+++ b/packages/altair-core/src/utils/dot-notation.spec.ts
@@ -47,5 +47,17 @@ describe('setByDotNotation', () => {
     setByDotNotation(polluted, '__proto__.polluted', 'polluted');
     expect((polluted as any).polluted).toBeUndefined();
     expect(({} as any).polluted).toBeUndefined();
+
+    setByDotNotation(polluted, 'constructor.prototype.polluted', 'polluted');
+    expect((polluted as any).polluted).toBeUndefined();
+    expect(({} as any).polluted).toBeUndefined();
+
+    // ensure valid paths with substrings are not blocked
+    const validObj: any = {};
+    setByDotNotation(validObj, 'myconstructor', 'is-ok');
+    expect(validObj.myconstructor).toBe('is-ok');
+
+    setByDotNotation(validObj, 'some_prototype_value', 'is-ok');
+    expect(validObj.some_prototype_value).toBe('is-ok');
   });
 });

--- a/packages/altair-core/src/utils/dot-notation.ts
+++ b/packages/altair-core/src/utils/dot-notation.ts
@@ -28,16 +28,21 @@ export function setByDotNotation<TResult = unknown>(
   if (!path || path.length === 0) {
     return undefined;
   }
-  if (path.includes('__proto__') || path.includes('constructor') || path.includes('prototype')) {
-    return undefined;
-  }
   if (typeof path === 'string') {
+    const segments = path.split('.').map(parseDotNotationKey);
+    if (segments.some(segment => segment === '__proto__' || segment === 'constructor' || segment === 'prototype')) {
+      return undefined;
+    }
     return setByDotNotation(
       obj,
-      path.split('.').map(parseDotNotationKey),
+      segments,
       value,
       merge
     );
+  }
+
+  if (Array.isArray(path) && path.some(segment => segment === '__proto__' || segment === 'constructor' || segment === 'prototype')) {
+    return undefined;
   }
 
   const currentPath = path[0];


### PR DESCRIPTION
Overview
This PR fixes a Prototype Pollution vulnerability in the setByDotNotation utility function located in packages/altair-core/src/utils/dot-notation.ts. The previous implementation did not validate path segments, allowing attackers to modify Object.prototype using keys such as proto, constructor, or prototype.

Root Cause
The setByDotNotation function recursively assigns values based on user-controlled dot-notation paths without filtering dangerous keys that can mutate JavaScript prototypes.

What This PR Changes

Adds validation to block unsafe keys: proto, prototype, and constructor.

Prevents prototype mutation at any depth during path traversal.

Ensures safe nested object assignment without affecting global prototypes.

Impact of the Vulnerability (before fix)
An attacker could pollute Object.prototype, which may lead to:

Denial of Service (DoS) by overwriting native Object methods

Logic bypasses and unintended behavior

Potential Remote Code Execution (RCE) in specific gadget-based scenarios

Application-wide instability or unexpected side effects

Steps to Reproduce (before fix)
import { setByDotNotation } from './dot-notation';

const victim = {};
setByDotNotation(victim, 'proto.polluted', 'yes');

const test = {};
console.log((test as any).polluted);
// Output: "yes" (vulnerable)

Recommendation / Fix Strategy

Reject unsafe path segments proactively.

Prevent assignments to proto, constructor, or prototype.

Maintain compatibility for all valid dot-notation paths.

Severity
High — The vulnerability allows prototype pollution, which can compromise the entire application.

Notes
The fix is minimal and targeted. Additional hardening or refactoring can be done in future updates if needed.
 #2951

## Summary by Sourcery

Prevent prototype pollution in the setByDotNotation utility by rejecting unsafe path segments.

Bug Fixes:
- Block assignments via setByDotNotation when the dot-notation path contains __proto__, constructor, or prototype to avoid mutating global prototypes.

Tests:
- Add a regression test ensuring setByDotNotation does not introduce polluted properties on created objects or Object.prototype via __proto__ paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security: prevented prototype pollution in dot-notation assignment operations by blocking traversal into prototype-related keys.

* **Tests**
  * Added tests validating the prototype-pollution protections and confirming valid, non-reserved paths remain writable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->