### PR TITLE
added support for allowedLocalStorageKeys

### DIFF
--- a/packages/altair-app/src/app/modules/altair/utils/settings_addons.ts
+++ b/packages/altair-app/src/app/modules/altair/utils/settings_addons.ts
@@ -1,6 +1,7 @@
 import { jsonc } from '../utils';
 import { JSONSchema6, JSONSchema6Definition } from 'json-schema';
 import settingsValidator from 'altair-graphql-core/build/typegen/validate-settings';
+import { debug } from './logger';
 
 export interface SchemaFormProperty extends JSONSchema6 {
   key: string;
@@ -12,6 +13,9 @@ export const settingsSchema = settingsValidator.schema;
 export const validateSettings = (settings: string) => {
   const data = jsonc(settings);
   const valid = settingsValidator(data);
+  if (!valid) {
+    debug.log('validator errors', settingsValidator.errors);
+  }
 
   return valid;
 };

--- a/packages/altair-core/src/types/state/settings.interfaces.ts
+++ b/packages/altair-core/src/types/state/settings.interfaces.ts
@@ -164,6 +164,14 @@ export interface SettingsState {
   'script.allowedCookies'?: string[];
 
   /**
+   * List of local storage keys to be accessible in the pre-request script.
+   * These will be made available read-only via the `storage` API in the script context.
+   * @example ['key1', 'key2']
+   * @default []
+   */
+  'script.allowedLocalStorageKeys'?: string[];
+
+  /**
    * Enable the scrollbar in the tab list
    */
   enableTablistScrollbar?: boolean;

--- a/packages/altair-docs/docs/features/prerequest-scripts.md
+++ b/packages/altair-docs/docs/features/prerequest-scripts.md
@@ -81,7 +81,7 @@ const res = await altair.helpers.request(
 
 ### altair.storage
 
-**`altair.storage.get(key: string): Promise<any>`** - Retrieves a value persisted in storage.
+**`altair.storage.get(key: string): Promise<any>`** - Retrieves a value persisted in storage. Also retrieves values from localStorage if the key is included in the `script.allowedLocalStorageKeys` setting.
 
 **`altair.storage.set(key: string, value: any): Promise<void>`** - Stores (persists) a value in storage for retrieval later.
 


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Allow pre-request scripts to read specific browser localStorage keys via the storage API, configurable through settings.

New Features:
- Add a settings option to whitelist localStorage keys accessible (read-only) from pre-request scripts via the storage API.

Enhancements:
- Log validation errors when settings JSON fails schema validation to aid debugging.

Documentation:
- Document that altair.storage.get can also read from localStorage for keys permitted by the script.allowedLocalStorageKeys setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-request scripts can read browser localStorage keys listed in the new allowedLocalStorageKeys setting (read-only; access emits a warning).

* **Improvements**
  * Added debug logging for settings validation failures.

* **Documentation**
  * Updated pre-request script storage documentation to describe allowedLocalStorageKeys and localStorage read behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->