### PR TITLE
fix: remove redundant 401 application error notification

### DIFF
--- a/packages/altair-app/src/app/modules/altair/services/gql/gql.service.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/services/gql/gql.service.spec.ts
@@ -899,4 +899,31 @@ describe('GqlService', () => {
       }
     ));
   });
+
+  describe('.sendRequestV2()', () => {
+    it('should throw error without notification when request fails', inject(
+      [GqlService],
+      async (service: GqlService) => {
+        mockRequestHandler.handle = () => {
+          return throwError(() => new Error('Network error'));
+        };
+
+        try {
+          await service
+            .sendRequestV2({
+              url: 'http://test.com',
+              method: 'GET',
+              query: '{}',
+              windowId: 'window-id',
+              handler: mockRequestHandler,
+            })
+            .pipe(take(1))
+            .toPromise();
+        } catch (err) {
+          expect(err).toBeTruthy();
+          expect(mockNotifyService.error).not.toHaveBeenCalled();
+        }
+      }
+    ));
+  });
 });

--- a/packages/altair-app/src/app/modules/altair/services/gql/gql.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/gql/gql.service.ts
@@ -696,13 +696,6 @@ export class GqlService {
           );
       }),
 
-      catchError((err) => {
-        if (err instanceof Error) {
-          this.notifyService.error(err.message);
-        }
-        debug.error(err);
-        throw err;
-      })
     );
   }
 }


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Remove redundant error notification when GraphQL request sending fails and ensure behavior is covered by tests.

Bug Fixes:
- Stop showing an application error notification when sendRequestV2 fails and rethrows the error instead.

Tests:
- Add a unit test verifying that sendRequestV2 propagates request errors without triggering the notification service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified GraphQL request error handling to propagate errors without user notifications.

* **Tests**
  * Added test coverage for error propagation in GraphQL requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->