### PR TITLE
fix electron and docker push

### DIFF
--- a/.github/workflows/_publish-electron.yml
+++ b/.github/workflows/_publish-electron.yml
@@ -94,6 +94,8 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     # Map the job output(s) to step output(s)
     outputs:
       version: ${{ steps.getversion.outputs.version }}

--- a/.github/workflows/_push-docker.yml
+++ b/.github/workflows/_push-docker.yml
@@ -54,6 +54,9 @@ jobs:
       - run: echo "Exposing env vars"
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,8 +68,10 @@ jobs:
   docker:
     needs: [vars, prepare-release]
     if: ${{ !cancelled() && !failure() }}
-    # We do not need to check out the repository to use the reusable workflow
     uses: ./.github/workflows/_push-docker.yml
+    permissions:
+      contents: read
+      packages: write
     with:
       # Push if on master or if it's a release
       push: ${{ needs.vars.outputs.type == 'master' || needs.vars.outputs.type == 'release' }}
@@ -85,6 +87,8 @@ jobs:
     needs: [vars, prepare-release]
     if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/_publish-electron.yml
+    permissions:
+      contents: write
     with:
       node_version: ${{ needs.vars.outputs.node_version }}
       publish: ${{ needs.vars.outputs.type == 'release' }}
@@ -106,7 +110,6 @@ jobs:
   npm:
     needs: [vars, prepare-release]
     if: ${{ !cancelled() && !failure() }}
-    # We do not need to check out the repository to use the reusable workflow
     uses: ./.github/workflows/_publish-npm.yml
     permissions:
       contents: write
@@ -122,7 +125,6 @@ jobs:
     uses: ./.github/workflows/_publish-tauri.yml
     permissions:
       contents: write
-      id-token: write
     with:
       node_version: ${{ needs.vars.outputs.node_version }}
       publish: ${{ needs.vars.outputs.type == 'release' }}


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Adjust GitHub Actions workflow permissions for Docker and Electron publishing jobs.

CI:
- Grant explicit contents read and packages write permissions to the Docker publish workflow and its reusable push-docker job.
- Grant contents write permissions to the Electron publish workflow and its reusable publish-electron job.
- Remove the unused id-token write permission from the Tauri publish workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions for improved security and build pipeline consistency across deployment jobs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->