### PR TITLE
make initialSettings and initialSubscriptionsPayload nullable

### DIFF
--- a/packages/altair-core/src/config/options.schema.ts
+++ b/packages/altair-core/src/config/options.schema.ts
@@ -195,9 +195,9 @@ export const altairConfigOptionsSchema = altairWindowOptionsSchema.extend({
    */
   initialSettings: settingsSchema
     .partial()
-    .nullable()
     .meta({ description: 'Initial app settings to use' })
-    .optional(),
+    .optional()
+    .nullable(),
 
   /**
    * Indicates if the state should be preserved for subsequent app loads


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->
#2971 

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Allow configuration options for initial subscriptions payload and initial app settings to be explicitly null in the Altair config schema.

Enhancements:
- Relax validation schema to accept null for initialSubscriptionsPayload connection params.
- Relax validation schema to accept null for initialSettings configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration schema now accepts null for the initial subscriptions payload and for initial settings, allowing more flexible startup configurations and preventing validation failures when those values are intentionally null.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->