### PR TITLE
improve startup time: don't wait for plugins

### DIFF
--- a/packages/altair-app/src/app/modules/altair/containers/altair/altair.component.ts
+++ b/packages/altair-app/src/app/modules/altair/containers/altair/altair.component.ts
@@ -9,7 +9,7 @@ import {
 } from 'rxjs/operators';
 import { Component, inject } from '@angular/core';
 import { Store, select } from '@ngrx/store';
-import { Observable, forkJoin, of, from, firstValueFrom } from 'rxjs';
+import { Observable, of, from, firstValueFrom } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 
 import { v4 as uuid } from 'uuid';
@@ -190,38 +190,40 @@ export class AltairComponent {
     this.setAvailableLanguages();
 
     const applicationLanguage = this.getAppLanguage();
-    forkJoin([
-      this.translate.use(applicationLanguage),
-      this.store.pipe(
-        take(1),
-        switchMap((data) => {
-          if (data.settings['plugin.list']) {
-            data.settings['plugin.list'].forEach((pluginStr) => {
-              const pluginInfo =
-                this.pluginRegistry.getPluginInfoFromString(pluginStr);
-              if (pluginInfo) {
-                this.pluginRegistry.fetchPlugin(pluginInfo.name, pluginInfo);
-              }
-            });
-          }
-          // this.pluginRegistry.fetchPlugin('altair-graphql-plugin-graphql-explorer', { version: '0.0.6' });
-          // this.pluginRegistry.fetchPlugin('altair-graphql-plugin-birdseye', {
-          //   pluginSource: 'url',
-          //   version: '0.0.4',
-          //   url: 'http://localhost:8002/'
-          // });
-          return from(this.pluginRegistry.pluginsReady());
-        }),
-        // Only wait 7 seconds for plugins to be ready
-        timeout(7000),
-        catchError((_error) => of('Plugins were not ready on time!'))
-      ),
-    ])
+    this.translate
+      .use(applicationLanguage)
       .pipe(untilDestroyed(this))
       .subscribe(() => {
         this.isReady = true;
         this.pluginEvent.emit('app-ready', true);
       });
+
+    // Load plugins in the background without blocking app ready
+    this.store.pipe(
+      take(1),
+      switchMap((data) => {
+        if (data.settings['plugin.list']) {
+          data.settings['plugin.list'].forEach((pluginStr) => {
+            const pluginInfo =
+              this.pluginRegistry.getPluginInfoFromString(pluginStr);
+            if (pluginInfo) {
+              this.pluginRegistry.fetchPlugin(pluginInfo.name, pluginInfo);
+            }
+          });
+        }
+        // this.pluginRegistry.fetchPlugin('altair-graphql-plugin-graphql-explorer', { version: '0.0.6' });
+        // this.pluginRegistry.fetchPlugin('altair-graphql-plugin-birdseye', {
+        //   pluginSource: 'url',
+        //   version: '0.0.4',
+        //   url: 'http://localhost:8002/'
+        // });
+        return from(this.pluginRegistry.pluginsReady());
+      }),
+      // Only wait 7 seconds for plugins to be ready
+      timeout(7000),
+      catchError((_error) => of('Plugins were not ready on time!')),
+      untilDestroyed(this)
+    ).subscribe();
 
     // Update the app translation if the language settings is changed.
     // TODO: Consider moving this into a settings effect.

--- a/packages/altair-app/src/app/modules/altair/services/plugin/plugin-event.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/plugin/plugin-event.service.ts
@@ -5,7 +5,7 @@ import {
   PluginEventCallback,
   PluginEventPayloadMap,
 } from 'altair-graphql-core/build/plugin/event/event.interfaces';
-import { Subject, Subscription } from 'rxjs';
+import { Subject, ReplaySubject, Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 interface PluginEventData<E extends PluginEvent = PluginEvent> {
@@ -20,6 +20,7 @@ export class PluginEventService {
   private errorHandler = inject(ErrorHandler);
 
   private eventStream = new Subject<PluginEventData>();
+  private appReadyStream = new ReplaySubject<PluginEventPayloadMap['app-ready']>(1);
 
   /**
    * Creates a group for managing multiple subscriptions within single contexts
@@ -32,6 +33,10 @@ export class PluginEventService {
    * Pushes an event data to the stream
    */
   emit<E extends PluginEvent>(event: E, payload: PluginEventPayloadMap[E]) {
+    // FIXME: Refactor this to avoid special handling for 'app-ready' event
+    if (event === 'app-ready') {
+      this.appReadyStream.next(payload as PluginEventPayloadMap['app-ready']);
+    }
     return this.eventStream.next({
       event,
       payload,
@@ -42,6 +47,15 @@ export class PluginEventService {
    * Subscribe to specific event
    */
   on<E extends PluginEvent>(event: E, callback: PluginEventCallback<E>) {
+    if (event === 'app-ready') {
+      return this.appReadyStream.subscribe((payload) => {
+        try {
+          callback(payload as PluginEventPayloadMap[E]);
+        } catch (error) {
+          this.errorHandler.handleError(error);
+        }
+      });
+    }
     return this.eventStream
       .pipe(filter((_): _ is PluginEventData<E> => _.event === event))
       .subscribe((evtData) => {


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Decouple application readiness from plugin loading to improve startup responsiveness.

Enhancements:
- Trigger the app-ready event as soon as translation is initialized without waiting for plugins to finish loading.
- Load configured plugins asynchronously in the background while still enforcing a timeout for plugin readiness.
- Ensure app-ready plugin events are replayed to late subscribers using a dedicated replayable event stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Faster app startup with improved initialization sequencing—the app becomes ready immediately after loading language preferences
  * Plugins now load asynchronously in the background without blocking initial app readiness

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/altair-graphql/altair/pull/3232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->