### PR TITLE
allow multiple account providers

### DIFF
--- a/packages/altair-api/src/auth/user/user.service.ts
+++ b/packages/altair-api/src/auth/user/user.service.ts
@@ -102,6 +102,31 @@ export class UserService {
       return user;
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        // If providerInfo is provided, try to link the new provider to the existing user
+        if (providerInfo) {
+          const existingUser = await this.prisma.user.findUnique({
+            where: { email: payload.email },
+          });
+          if (existingUser) {
+            await this.prisma.userCredential.upsert({
+              where: {
+                userId_provider: {
+                  userId: existingUser.id,
+                  provider: providerInfo.provider,
+                },
+              },
+              create: {
+                userId: existingUser.id,
+                provider: providerInfo.provider,
+                providerUserId: providerInfo.providerUserId,
+              },
+              update: {
+                providerUserId: providerInfo.providerUserId,
+              },
+            });
+            return existingUser;
+          }
+        }
         throw new ConflictException(`Email ${payload.email} already used.`);
       }
       throw e;


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

New Features:
- Allow associating an additional auth provider with an existing user based on email when a unique constraint violation occurs during user creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced provider account linking: Users can now seamlessly connect multiple authentication providers to a single account. If you attempt to register with a provider using an email associated with an existing account, the system will automatically link the new provider to your existing account instead of returning an error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/altair-graphql/altair/pull/3233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->