### PR TITLE
fix indirect eval in worker script evaluator

### DIFF
--- a/packages/altair-app/src/app/modules/altair/services/query/query.service.spec.ts
+++ b/packages/altair-app/src/app/modules/altair/services/query/query.service.spec.ts
@@ -37,6 +37,9 @@ const makeWindowState = (overrides: Partial<PerWindowState> = {}): PerWindowStat
     preRequest: { enabled: false, script: '' },
     postRequest: { enabled: false, script: '' },
     authorization: { type: 'none', data: {} },
+    layout: {
+      title: 'Test Window',
+    },
     ...overrides,
   }) as unknown as PerWindowState;
 
@@ -67,7 +70,8 @@ describe('QueryService', () => {
         MockProvider(PreRequestService),
         {
           provide: Store,
-          useFactory: () => mockStoreFactory(),
+          useFactory: () =>
+            mockStoreFactory(),
         },
       ],
       teardown: { destroyAfterEach: false },
@@ -380,9 +384,9 @@ describe('QueryService', () => {
       vi.spyOn(service, 'getWindowState').mockResolvedValue(state);
 
       const mockPreRequest = TestBed.inject(PreRequestService);
-      vi
-        .spyOn(mockPreRequest, 'executeScript')
-        .mockRejectedValue(new Error('Script error'));
+      vi.spyOn(mockPreRequest, 'executeScript').mockRejectedValue(
+        new Error('Script error')
+      );
 
       const mockNotify = TestBed.inject(NotifyService);
       const errorSpy = vi.spyOn(mockNotify, 'error');
@@ -444,9 +448,9 @@ describe('QueryService', () => {
       vi.spyOn(service, 'getWindowState').mockResolvedValue(state);
 
       const mockPreRequest = TestBed.inject(PreRequestService);
-      vi
-        .spyOn(mockPreRequest, 'executeScript')
-        .mockRejectedValue(new Error('Post script error'));
+      vi.spyOn(mockPreRequest, 'executeScript').mockRejectedValue(
+        new Error('Post script error')
+      );
 
       const mockNotify = TestBed.inject(NotifyService);
       const errorSpy = vi.spyOn(mockNotify, 'error');

--- a/packages/altair-app/src/app/modules/altair/services/query/query.service.ts
+++ b/packages/altair-app/src/app/modules/altair/services/query/query.service.ts
@@ -99,7 +99,11 @@ export class QueryService {
       };
     } catch (err) {
       debug.error(err);
-      this.notifyService.error(`Error executing pre-request script: ${err}`);
+      this.notifyService.error(
+        `Error executing pre-request script: ${err}`,
+        `[${state.layout.title}]`,
+        {}
+      );
 
       return preTransformedData;
     }

--- a/packages/altair-core/src/script/evaluator-worker-engine.ts
+++ b/packages/altair-core/src/script/evaluator-worker-engine.ts
@@ -67,9 +67,13 @@ export class ScriptEvaluatorWorkerEngine {
       };
 
       try {
-        return this.evalWithContext(script, context).then((result) => {
-          return resolve(result);
-        });
+        return this.evalWithContext(script, context)
+          .then((result) => {
+            return resolve(result);
+          })
+          .catch((err) => {
+            reject(err);
+          });
       } catch (e) {
         return reject(e);
       }

--- a/packages/altair-core/src/script/evaluator-worker-engine.ts
+++ b/packages/altair-core/src/script/evaluator-worker-engine.ts
@@ -3,6 +3,7 @@ import { ScriptEvaluatorClientEngine } from './evaluator-client-engine';
 import { SCRIPT_INIT_EXECUTE } from './events';
 import {
   AllScriptEventHandlers,
+  GlobalHelperContext,
   ScriptContextData,
   ScriptEvaluatorWorker,
   ScriptEvent,
@@ -65,17 +66,10 @@ export class ScriptEvaluatorWorkerEngine {
         alert: (msg: string) => this.makeCall('alert', msg),
       };
 
-      const contextEntries = Object.entries(context);
       try {
-        const res = function () {
-          return (0, eval)(`
-          (async(${contextEntries.map((e) => e[0]).join(',')}) => {
-            ${script};
-            return altair.data;
-          })(...this.__ctxE.map(e => e[1]));
-        `);
-        }.call({ __ctxE: contextEntries });
-        return resolve(res);
+        return this.evalWithContext(script, context).then((result) => {
+          return resolve(result);
+        });
       } catch (e) {
         return reject(e);
       }
@@ -111,5 +105,22 @@ export class ScriptEvaluatorWorkerEngine {
       });
       this.worker.send(type, { id, args });
     });
+  }
+
+  private async evalWithContext(
+    script: string,
+    context: {
+      altair: GlobalHelperContext;
+      alert: (msg: string) => Promise<Promise<void>>;
+    }
+  ) {
+    const contextEntries = Object.entries(context);
+    const fn = (0, eval)(`
+      async (${contextEntries.map((e) => e[0]).join(',')}) => {
+        ${script};
+        return altair.data;
+      }
+    `);
+    return fn(...contextEntries.map((e) => e[1]));
   }
 }

--- a/packages/altair-core/src/script/evaluator-worker-engine.ts
+++ b/packages/altair-core/src/script/evaluator-worker-engine.ts
@@ -66,17 +66,13 @@ export class ScriptEvaluatorWorkerEngine {
         alert: (msg: string) => this.makeCall('alert', msg),
       };
 
-      try {
-        return this.evalWithContext(script, context)
-          .then((result) => {
-            return resolve(result);
-          })
-          .catch((err) => {
-            reject(err);
-          });
-      } catch (e) {
-        return reject(e);
-      }
+      return this.evalWithContext(script, context)
+        .then((result) => {
+          return resolve(result);
+        })
+        .catch((err) => {
+          reject(err);
+        });
     });
 
     if (res.__toSetActiveEnvironment) {

--- a/packages/altair-electron/electron-builder.yml
+++ b/packages/altair-electron/electron-builder.yml
@@ -48,7 +48,7 @@ linux:
     # - flatpak
 appImage:
   category: Development
-snapcraft:
+snap:
   base: core24
   publish:
     - provider: github


### PR DESCRIPTION
### Fixes #
<!-- Mention the issues this PR addresses -->

### Checks

- [ ] Ran `yarn test-build`
- [ ] Updated relevant documentations
- [ ] Updated matching config options in altair-static

### Changes proposed in this pull request:
<!-- Describe the changes being introduced in this PR -->

## Summary by Sourcery

Fix script evaluation in the worker engine and improve error reporting and packaging config.

Bug Fixes:
- Correct script execution in the worker-based evaluator by moving context-aware eval into a dedicated helper to avoid indirect eval issues.
- Improve pre-request script error handling by providing clearer notification context when execution fails.

Build:
- Update Electron builder configuration to use the modern snap configuration key instead of the deprecated snapcraft entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error notification for pre-request script failures with clearer message and title context

* **Refactor**
  * Centralized script evaluation into a single helper for more consistent execution and context handling

* **Tests**
  * Reformatted unit tests and mocks for script-execution failure scenarios without changing behavior

* **Chores**
  * Renamed Snap packaging key in build configuration for Linux builds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->