### PR TITLE
fix: import-curl-dialog text colour changed to black

### DIFF
--- a/packages/altair-app/src/app/modules/altair/components/import-curl-dialog/import-curl-dialog.component.scss
+++ b/packages/altair-app/src/app/modules/altair/components/import-curl-dialog/import-curl-dialog.component.scss
@@ -1,0 +1,3 @@
+.dialog-textarea {
+  color: black;
+}


### PR DESCRIPTION
### Fixes #
Resolves #3245
On changing the color of the textarea to black, the text is now visible in both light and dark modes.

## Summary by Sourcery

Bug Fixes:
- Ensure import cURL dialog textarea text remains visible by explicitly setting its text color to black.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text styling in the import curl dialog for improved visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->